### PR TITLE
fix+feat: Makefile mypy gate, bsela status --json, P7 replay harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ format-check:
 	uv run ruff format --check .
 
 type:
-	uv run mypy src tests
+	uv run --extra dev mypy src tests
 
 test:
 	uv run pytest -q

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -11,7 +11,7 @@
 | **P4 — MVP Dogfood** | 🔄 active | 7 days | Daily use. Measure lesson quality, false positives. Tune thresholds. Self-serve tooling in place (`bsela report`, `bsela process`, `bsela hook install`, `bsela decision`, weekly launchd plist). Remaining work is runtime — ingest live sessions, inspect output, tune. |
 | **P5 — Router + Auditor** | 🔄 scaffolded | 5 days | Task classifier + weekly `launchd` audit. `bsela route` and `bsela audit` land behind ADR 0005 in parallel with P4 dogfood; declared shipped once dogfood data validates routing + auditor alerts. |
 | **P6 — MCP + Multi-editor** | 🔄 scaffolded | 7 days | MCP server (TypeScript) + Codex/Windsurf adapters. `mcp/` TS workspace bootstrapped behind ADR 0006 with a read-only `BselaClient` and a stdio MCP server binary (`bsela-mcp`) exposing `bsela_route`, `bsela_audit`, `bsela_status`. CI runs `pnpm check` on `mcp/**` PRs. Codex + Windsurf adapter snippets landed under [`adapters/`](../adapters/README.md); only real-editor validation against live BSELA state still gates "shipped". |
-| **P7 — A/B + Drift** | ⬜ | 5 days | Replay harness, drift alarms, rollback tooling. |
+| **P7 — A/B + Drift** | 🔄 scaffolded | 5 days | Replay harness, drift alarms, rollback tooling. `bsela replay <session-id>` lands as `core/replay.py` + CLI command; diffs stored vs. re-distilled lessons, exits 1 on drift. Drift alarms and `bsela rollback` still pending. |
 
 ## MVP Scope (P0–P4)
 

--- a/mcp/src/bsela-client.ts
+++ b/mcp/src/bsela-client.ts
@@ -34,6 +34,15 @@ export interface RouteDecision {
   matched_keywords: Array<string>;
 }
 
+export interface StatusPayload {
+  sessions: number;
+  sessions_quarantined: number;
+  errors: number;
+  lessons: number;
+  lessons_pending: number;
+  bsela_home: string;
+}
+
 export interface BselaClientOptions {
   binary?: string;
   cwd?: string;
@@ -136,6 +145,19 @@ function isRouteDecision(value: unknown): value is RouteDecision {
   );
 }
 
+function isStatusPayload(value: unknown): value is StatusPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.sessions === "number" &&
+    typeof v.sessions_quarantined === "number" &&
+    typeof v.errors === "number" &&
+    typeof v.lessons === "number" &&
+    typeof v.lessons_pending === "number" &&
+    typeof v.bsela_home === "string"
+  );
+}
+
 export class BselaClient {
   private readonly options: BselaClientOptions;
 
@@ -170,10 +192,18 @@ export class BselaClient {
     return result.stdout;
   }
 
-  async status(): Promise<string> {
-    const args = ["status"];
+  async status(): Promise<StatusPayload> {
+    const args = ["status", "--json"];
     const result = await runBsela(args, this.options);
     assertSuccess(args, result);
-    return result.stdout;
+    const parsed = parseJson(result.stdout.trim());
+    if (!isStatusPayload(parsed)) {
+      throw new BselaClientError(
+        "bsela status returned an unexpected payload shape",
+        result.exitCode,
+        JSON.stringify(parsed).slice(0, 200),
+      );
+    }
+    return parsed;
   }
 }

--- a/mcp/src/bsela-client.ts
+++ b/mcp/src/bsela-client.ts
@@ -14,6 +14,8 @@
  */
 
 import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 export type TaskClass =
   | "judge"
@@ -63,11 +65,21 @@ export class BselaClientError extends Error {
 }
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BSELA_CONFIG_DIR = resolve(MODULE_DIR, "..", "..", "config");
 
 interface RunResult {
   stdout: string;
   stderr: string;
   exitCode: number | null;
+}
+
+function resolveEnv(env: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+  const merged = { ...process.env, ...(env ?? {}) };
+  if (!merged["BSELA_CONFIG_DIR"]) {
+    merged["BSELA_CONFIG_DIR"] = DEFAULT_BSELA_CONFIG_DIR;
+  }
+  return merged;
 }
 
 function runBsela(
@@ -79,7 +91,7 @@ function runBsela(
   return new Promise((resolve, reject) => {
     const child = spawn(binary, args, {
       cwd: options?.cwd,
-      env: options?.env ?? process.env,
+      env: resolveEnv(options?.env),
       stdio: ["ignore", "pipe", "pipe"],
     });
 

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -11,6 +11,7 @@ export {
   BselaClientError,
   type BselaClientOptions,
   type RouteDecision,
+  type StatusPayload,
   type TaskClass,
 } from "./bsela-client.js";
 

--- a/mcp/src/server-tools.ts
+++ b/mcp/src/server-tools.ts
@@ -12,7 +12,7 @@
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 
-import { BselaClientError, type BselaClient } from "./bsela-client.js";
+import { BselaClientError, type BselaClient, type StatusPayload } from "./bsela-client.js";
 
 export type ToolTextResult = CallToolResult;
 
@@ -72,9 +72,10 @@ export async function handleAudit(
 
 export async function handleStatus(client: BselaClient): Promise<ToolTextResult> {
   try {
-    const text = await client.status();
+    const payload: StatusPayload = await client.status();
     return {
-      content: [{ type: "text", text }],
+      content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+      structuredContent: payload as unknown as Record<string, unknown>,
     };
   } catch (err) {
     return errorResult(err, "bsela status failed");

--- a/mcp/tests/bsela-client.test.ts
+++ b/mcp/tests/bsela-client.test.ts
@@ -1,3 +1,6 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import { describe, expect, it } from "vitest";
 
 import { BselaClient, BselaClientError } from "../src/index.js";
@@ -6,9 +9,19 @@ import { BselaClient, BselaClientError } from "../src/index.js";
  * These are integration tests: they shell out to the `bsela`
  * Python CLI that ships with this repo. `bsela` must be on PATH
  * and `.venv` must be initialised (`uv sync` + `uv tool install -e .`).
+ *
+ * We prepend `~/.local/bin` to PATH so the uv-installed binary (which
+ * tracks the current worktree) wins over pyenv shims, which may point
+ * to an older install from the main branch.
  */
+function makeClient(): BselaClient {
+  const localBin = join(homedir(), ".local", "bin");
+  const path = `${localBin}:${process.env["PATH"] ?? ""}`;
+  return new BselaClient({ env: { ...process.env, PATH: path } });
+}
+
 describe("BselaClient.route", () => {
-  const client = new BselaClient();
+  const client = makeClient();
 
   it("routes a planning task to the planner role", async () => {
     const decision = await client.route("plan the migration to P6");
@@ -33,7 +46,7 @@ describe("BselaClient.route", () => {
 });
 
 describe("BselaClient.audit", () => {
-  const client = new BselaClient();
+  const client = makeClient();
 
   it("returns markdown starting with the audit header", async () => {
     const markdown = await client.audit({ windowDays: 30 });
@@ -43,11 +56,17 @@ describe("BselaClient.audit", () => {
 });
 
 describe("BselaClient.status", () => {
-  const client = new BselaClient();
+  const client = makeClient();
 
-  it("prints the BSELA home and counts", async () => {
-    const output = await client.status();
-    expect(output).toMatch(/(BSELA home|no store)/);
+  it("returns a typed StatusPayload with numeric counts and bsela_home", async () => {
+    const payload = await client.status();
+    expect(typeof payload.sessions).toBe("number");
+    expect(typeof payload.sessions_quarantined).toBe("number");
+    expect(typeof payload.errors).toBe("number");
+    expect(typeof payload.lessons).toBe("number");
+    expect(typeof payload.lessons_pending).toBe("number");
+    expect(typeof payload.bsela_home).toBe("string");
+    expect(payload.bsela_home.length).toBeGreaterThan(0);
   });
 });
 

--- a/mcp/tests/server-tools.test.ts
+++ b/mcp/tests/server-tools.test.ts
@@ -15,6 +15,7 @@ import {
   handleStatus,
   toolDefinitions,
   type RouteDecision,
+  type StatusPayload,
 } from "../src/index.js";
 
 function stubClient(overrides: Partial<BselaClient> = {}): BselaClient {
@@ -113,15 +114,25 @@ describe("handleAudit", () => {
 });
 
 describe("handleStatus", () => {
-  it("returns the raw status text", async () => {
-    const status = vi.fn().mockResolvedValue("BSELA home: /tmp/.bsela\n");
+  it("returns structured JSON payload with counts and bsela_home", async () => {
+    const payload: StatusPayload = {
+      sessions: 3,
+      sessions_quarantined: 1,
+      errors: 5,
+      lessons: 2,
+      lessons_pending: 1,
+      bsela_home: "/tmp/.bsela",
+    };
+    const status = vi.fn().mockResolvedValue(payload);
     const client = stubClient({ status });
 
     const result = await handleStatus(client);
 
     expect(status).toHaveBeenCalledWith();
     expect(result.isError).toBeUndefined();
-    expect((result.content[0] as { text: string }).text).toContain("BSELA home");
+    const text = (result.content[0] as { text: string }).text;
+    expect(JSON.parse(text)).toEqual(payload);
+    expect(result.structuredContent).toEqual(payload);
   });
 
   it("returns an error result when the client throws", async () => {

--- a/mcp/tests/server.test.ts
+++ b/mcp/tests/server.test.ts
@@ -8,7 +8,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it, vi } from "vitest";
 
-import { BselaClient, createServer, type RouteDecision } from "../src/index.js";
+import { BselaClient, createServer, type RouteDecision, type StatusPayload } from "../src/index.js";
 
 function stubClient(overrides: Partial<BselaClient>): BselaClient {
   return Object.assign(Object.create(BselaClient.prototype), overrides) as BselaClient;
@@ -33,10 +33,18 @@ describe("createServer", () => {
       reason: "matched keyword",
       matched_keywords: ["plan"],
     };
+    const statusPayload: StatusPayload = {
+      sessions: 0,
+      sessions_quarantined: 0,
+      errors: 0,
+      lessons: 0,
+      lessons_pending: 0,
+      bsela_home: "/tmp/.bsela",
+    };
     const client = stubClient({
       route: vi.fn().mockResolvedValue(decision),
       audit: vi.fn().mockResolvedValue("# BSELA Weekly Audit\n"),
-      status: vi.fn().mockResolvedValue("BSELA home: /tmp/.bsela\n"),
+      status: vi.fn().mockResolvedValue(statusPayload),
     });
 
     const mcp = await connectClient(client);

--- a/src/bsela/cli.py
+++ b/src/bsela/cli.py
@@ -49,6 +49,7 @@ from bsela.core.process import (
 from bsela.core.process import (
     process_sessions,
 )
+from bsela.core.replay import replay_session
 from bsela.core.report import (
     DEFAULT_RECENT_LIMIT,
     DEFAULT_WINDOW_DAYS,
@@ -144,11 +145,30 @@ def main(
 
 
 @app.command()
-def status() -> None:
+def status(
+    as_json: Annotated[
+        bool,
+        typer.Option("--json", help="Emit counts as JSON for machine consumption."),
+    ] = False,
+) -> None:
     """Show storage metrics: sessions, errors, lessons, pending proposals."""
     home = bsela_home()
     if not db_path().exists():
-        typer.echo(f"status: no store at {home} yet — run `bsela ingest` first.")
+        if as_json:
+            typer.echo(
+                json.dumps(
+                    {
+                        "sessions": 0,
+                        "sessions_quarantined": 0,
+                        "errors": 0,
+                        "lessons": 0,
+                        "lessons_pending": 0,
+                        "bsela_home": str(home),
+                    }
+                )
+            )
+        else:
+            typer.echo(f"status: no store at {home} yet — run `bsela ingest` first.")
         raise typer.Exit(code=0)
 
     sessions_total = count_sessions()
@@ -157,10 +177,24 @@ def status() -> None:
     lessons_pending = count_lessons(status="pending")
     lessons_total = count_lessons()
 
-    typer.echo(f"BSELA home: {home}")
-    typer.echo(f"sessions: {sessions_total} (quarantined: {sessions_quarantined})")
-    typer.echo(f"errors:   {errors_total}")
-    typer.echo(f"lessons:  {lessons_total} (pending: {lessons_pending})")
+    if as_json:
+        typer.echo(
+            json.dumps(
+                {
+                    "sessions": sessions_total,
+                    "sessions_quarantined": sessions_quarantined,
+                    "errors": errors_total,
+                    "lessons": lessons_total,
+                    "lessons_pending": lessons_pending,
+                    "bsela_home": str(home),
+                }
+            )
+        )
+    else:
+        typer.echo(f"BSELA home: {home}")
+        typer.echo(f"sessions: {sessions_total} (quarantined: {sessions_quarantined})")
+        typer.echo(f"errors:   {errors_total}")
+        typer.echo(f"lessons:  {lessons_total} (pending: {lessons_pending})")
     raise typer.Exit(code=0)
 
 
@@ -310,6 +344,30 @@ def rollback(
     """Revert a previously applied lesson."""
     typer.echo(f"rollback {lesson_id}: not implemented (P7).")
     raise typer.Exit(code=0)
+
+
+@app.command()
+def replay(
+    session_id: Annotated[str, typer.Argument(help="Session ID to replay.")],
+) -> None:
+    """Re-distill a stored session and show a diff against its existing lessons.
+
+    Requires ANTHROPIC_API_KEY. Does not persist anything — the diff is
+    printed only so it can be inspected for drift.
+
+    Exit code 0: no drift (replayed lessons match stored).
+    Exit code 1: drift detected or session not found.
+    """
+    try:
+        llm = AnthropicClient.from_config()
+        result = replay_session(session_id, client=llm)
+    except LookupError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(result.summary())
+    drift = any(d.kind != "unchanged" for d in result.diff)
+    raise typer.Exit(code=1 if drift else 0)
 
 
 @decision_app.command("add")

--- a/src/bsela/core/replay.py
+++ b/src/bsela/core/replay.py
@@ -1,0 +1,130 @@
+"""Replay harness — P7 foundation.
+
+Re-runs the detector+distiller pipeline on a previously captured session
+without persisting the result, then diffs the candidate lessons against
+whatever lessons are already stored for that session.
+
+The diff is the signal: if the same session produces different lessons
+after a rule/prompt change, that's drift. The harness surfaces it so the
+operator can decide whether the drift is intentional improvement or
+regression.
+
+Usage:
+    result = replay_session(session_id, client=llm_client)
+    print(result.summary())
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from bsela.llm.client import LLMClient
+from bsela.llm.distiller import DistillationResult, distill_session
+from bsela.memory.models import Lesson
+from bsela.memory.store import get_session, list_lessons
+
+
+@dataclass(frozen=True)
+class LessonDiff:
+    """One entry in the diff between stored and replayed lessons."""
+
+    kind: str  # "added" | "removed" | "unchanged"
+    rule: str
+    confidence: float
+    scope: str
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Full replay outcome for one session."""
+
+    session_id: str
+    distilled: bool
+    stored_lessons: tuple[Lesson, ...]
+    replayed_lessons: tuple[Lesson, ...]
+    diff: tuple[LessonDiff, ...]
+
+    def summary(self) -> str:
+        if not self.distilled:
+            return f"session {self.session_id}: judge rated healthy — no lessons produced"
+        added = [d for d in self.diff if d.kind == "added"]
+        removed = [d for d in self.diff if d.kind == "removed"]
+        unchanged = [d for d in self.diff if d.kind == "unchanged"]
+        parts = [f"session {self.session_id}: replay diff"]
+        parts.append(
+            f"  stored={len(self.stored_lessons)}"
+            f"  replayed={len(self.replayed_lessons)}"
+            f"  +{len(added)} -{len(removed)} ={len(unchanged)}"
+        )
+        for d in self.diff:
+            prefix = {"added": "+", "removed": "-", "unchanged": "="}[d.kind]
+            parts.append(f"  {prefix} [{d.scope}] {d.rule} (conf={d.confidence:.2f})")
+        return "\n".join(parts)
+
+
+def _normalize(rule: str) -> str:
+    """Lowercase + collapse whitespace so minor formatting changes don't inflate diffs."""
+    return " ".join(rule.lower().split())
+
+
+def _diff_lessons(
+    stored: list[Lesson],
+    replayed: list[Lesson],
+) -> tuple[LessonDiff, ...]:
+    """Rule-level diff: exact match on normalised rule text."""
+    stored_rules = {_normalize(s.rule): s for s in stored}
+    replayed_rules = {_normalize(r.rule): r for r in replayed}
+
+    diffs: list[LessonDiff] = []
+    all_keys = stored_rules.keys() | replayed_rules.keys()
+    for key in sorted(all_keys):
+        if key in stored_rules and key in replayed_rules:
+            r = replayed_rules[key]
+            diffs.append(LessonDiff("unchanged", r.rule, r.confidence, r.scope))
+        elif key in replayed_rules:
+            r = replayed_rules[key]
+            diffs.append(LessonDiff("added", r.rule, r.confidence, r.scope))
+        else:
+            s = stored_rules[key]
+            diffs.append(LessonDiff("removed", s.rule, s.confidence, s.scope))
+    return tuple(diffs)
+
+
+def replay_session(
+    session_id: str,
+    *,
+    client: LLMClient,
+) -> ReplayResult:
+    """Re-distill a stored session without persisting; diff against current lessons.
+
+    Raises ``LookupError`` if ``session_id`` is not in the store.
+    """
+    session = get_session(session_id)
+    if session is None:
+        raise LookupError(f"session not found: {session_id}")
+
+    stored = list_lessons(session_id=session_id)
+
+    result: DistillationResult = distill_session(
+        session_id,
+        client=client,
+        persist=False,
+    )
+
+    replayed = list(result.persisted)
+    diff = _diff_lessons(stored, replayed)
+
+    return ReplayResult(
+        session_id=session_id,
+        distilled=result.distilled,
+        stored_lessons=tuple(stored),
+        replayed_lessons=tuple(replayed),
+        diff=diff,
+    )
+
+
+__all__ = [
+    "LessonDiff",
+    "ReplayResult",
+    "replay_session",
+]

--- a/src/bsela/memory/store.py
+++ b/src/bsela/memory/store.py
@@ -178,6 +178,7 @@ def list_lessons(
     *,
     status: str | None = None,
     scope: str | None = None,
+    session_id: str | None = None,
     limit: int = 100,
 ) -> list[Lesson]:
     stmt = select(Lesson).order_by(Lesson.created_at.desc())  # type: ignore[attr-defined]
@@ -185,6 +186,10 @@ def list_lessons(
         stmt = stmt.where(Lesson.status == status)
     if scope is not None:
         stmt = stmt.where(Lesson.scope == scope)
+    if session_id is not None:
+        stmt = stmt.join(ErrorRecord, Lesson.source_error_id == ErrorRecord.id).where(  # type: ignore[arg-type]
+            ErrorRecord.session_id == session_id
+        )
     stmt = stmt.limit(limit)
     with session_scope() as s:
         return list(s.exec(stmt).all())

--- a/tests/test_cli_ingest.py
+++ b/tests/test_cli_ingest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -36,3 +37,18 @@ def test_status_before_and_after_ingest(tmp_bsela_home: Path, sample_clean_sessi
     assert post.exit_code == 0
     assert "sessions: 1" in post.stdout
     assert "quarantined: 0" in post.stdout
+
+
+def test_status_json_after_ingest(tmp_bsela_home: Path, sample_clean_session: Path) -> None:
+    runner = CliRunner()
+    runner.invoke(app, ["ingest", str(sample_clean_session)])
+
+    result = runner.invoke(app, ["status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["sessions"] == 1
+    assert payload["sessions_quarantined"] == 0
+    assert isinstance(payload["errors"], int)
+    assert isinstance(payload["lessons"], int)
+    assert isinstance(payload["lessons_pending"], int)
+    assert "bsela_home" in payload

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -31,6 +32,20 @@ def test_status_exits_zero_when_store_missing(
     result = CliRunner().invoke(app, ["status"])
     assert result.exit_code == 0
     assert "no store" in result.stdout
+
+
+def test_status_json_exits_zero_when_store_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BSELA_HOME", str(tmp_path))
+    result = CliRunner().invoke(app, ["status", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["sessions"] == 0
+    assert payload["errors"] == 0
+    assert payload["lessons"] == 0
+    assert payload["lessons_pending"] == 0
+    assert "bsela_home" in payload
 
 
 def test_review_with_empty_store_exits_zero(

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,229 @@
+"""P7 tests: replay harness diffs stored vs. replayed lessons."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from bsela.cli import app
+from bsela.core.capture import ingest_file
+from bsela.core.detector import detect_errors
+from bsela.core.replay import LessonDiff, ReplayResult, replay_session
+from bsela.llm.client import FakeLLMClient
+from bsela.llm.types import DistillResponse, JudgeVerdict, LessonCandidate
+from bsela.memory.models import ErrorRecord, Lesson
+from bsela.memory.store import list_sessions, save_error, save_lesson
+
+FIXTURES = Path(__file__).parent / "fixtures" / "sample-sessions"
+
+
+def _unhealthy_verdict() -> JudgeVerdict:
+    return JudgeVerdict(
+        goal_achieved=False,
+        efficiency=0.3,
+        looped=True,
+        wasted_tokens=True,
+        confidence=0.6,
+    )
+
+
+def _healthy_verdict() -> JudgeVerdict:
+    return JudgeVerdict(
+        goal_achieved=True,
+        efficiency=0.9,
+        looped=False,
+        wasted_tokens=False,
+        confidence=0.95,
+    )
+
+
+def _distill_response(rule: str = "Do not retry on the same error twice") -> DistillResponse:
+    return DistillResponse(
+        status="ok",
+        confidence=0.88,
+        lessons=[
+            LessonCandidate(
+                rule=rule,
+                why="loop detector flagged retries",
+                how_to_apply="switch strategy after second failure",
+                scope="project",
+                confidence=0.88,
+                evidence={},
+            )
+        ],
+    )
+
+
+def _fake_client(
+    verdict: JudgeVerdict | None = None,
+    distill: DistillResponse | None = None,
+) -> FakeLLMClient:
+    return FakeLLMClient(
+        judge_response=verdict or _unhealthy_verdict(),
+        distill_response=distill or _distill_response(),
+    )
+
+
+def _seed_error(session_id: str) -> ErrorRecord:
+    """Persist a synthetic error for session_id so lessons can be JOIN-discovered."""
+    return save_error(
+        ErrorRecord(
+            session_id=session_id,
+            category="loop",
+            severity="medium",
+            snippet="fake snippet for test",
+        )
+    )
+
+
+# ---- core replay_session ----------------------------------------------------
+
+
+def test_replay_raises_for_missing_session(tmp_bsela_home: Path) -> None:
+    with pytest.raises(LookupError, match="session not found"):
+        replay_session("nonexistent-id", client=_fake_client())
+
+
+def test_replay_healthy_session_produces_no_diff(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    detect_errors(session_id)
+
+    client = _fake_client(verdict=_healthy_verdict())
+    result = replay_session(session_id, client=client)
+
+    assert not result.distilled
+    assert result.diff == ()
+    assert "healthy" in result.summary()
+
+
+def test_replay_no_stored_lessons_shows_all_added(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    detect_errors(session_id)
+
+    result = replay_session(session_id, client=_fake_client())
+
+    assert result.distilled
+    added = [d for d in result.diff if d.kind == "added"]
+    assert len(added) >= 1
+    assert result.replayed_lessons
+
+
+def test_replay_identical_lesson_shows_unchanged(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    rule = "Do not retry on the same error twice"
+    stored = save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=rule,
+            why="loop detected",
+            how_to_apply="switch strategy",
+            confidence=0.88,
+            status="pending",
+        )
+    )
+
+    result = replay_session(session_id, client=_fake_client(distill=_distill_response(rule)))
+
+    assert stored.id is not None
+    unchanged = [d for d in result.diff if d.kind == "unchanged"]
+    assert any(d.rule == rule for d in unchanged), result.diff
+
+
+def test_replay_changed_rule_shows_added_and_removed(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    old_rule = "Old rule that was superseded"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=old_rule,
+            why="old reason",
+            how_to_apply="old action",
+            confidence=0.7,
+            status="pending",
+        )
+    )
+
+    new_rule = "New improved rule after prompt update"
+    result = replay_session(session_id, client=_fake_client(distill=_distill_response(new_rule)))
+
+    kinds = {d.kind for d in result.diff}
+    assert "added" in kinds
+    assert "removed" in kinds
+
+
+def test_replay_diff_normalization_ignores_case_and_whitespace(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    base_rule = "Do not retry on the same error twice"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=base_rule.upper(),
+            why="reason",
+            how_to_apply="action",
+            confidence=0.8,
+            status="pending",
+        )
+    )
+
+    result = replay_session(
+        session_id,
+        client=_fake_client(distill=_distill_response(base_rule.lower())),
+    )
+
+    unchanged = [d for d in result.diff if d.kind == "unchanged"]
+    assert len(unchanged) >= 1
+
+
+# ---- ReplayResult.summary() -------------------------------------------------
+
+
+def test_summary_shows_session_id_and_counts() -> None:
+    result = ReplayResult(
+        session_id="abc-123",
+        distilled=True,
+        stored_lessons=(),
+        replayed_lessons=(),
+        diff=(
+            LessonDiff("added", "new rule", 0.9, "project"),
+            LessonDiff("removed", "old rule", 0.7, "project"),
+        ),
+    )
+    summary = result.summary()
+    assert "abc-123" in summary
+    assert "+1" in summary
+    assert "-1" in summary
+
+
+# ---- CLI bsela replay -------------------------------------------------------
+
+
+def test_cli_replay_not_found_exits_1(tmp_bsela_home: Path) -> None:
+    result = CliRunner().invoke(app, ["replay", "no-such-session"])
+    assert result.exit_code == 1
+    assert "not found" in result.stdout


### PR DESCRIPTION
## Summary

- **fix(ci):** `make check` was silently skipping type-checks because `uv run mypy` doesn't load `[optional-dependencies] dev`. Fixed to `uv run --extra dev mypy`.
- **feat(adapters):** `bsela status --json` emits the stable JSON payload (`sessions`, `sessions_quarantined`, `errors`, `lessons`, `lessons_pending`, `bsela_home`) that ADR 0006 flagged as a follow-up for the MCP contract. `BselaClient.status()` updated to return typed `StatusPayload`; `handleStatus` exposes `structuredContent`.
- **feat(core):** P7 replay harness — `bsela replay <session-id>` re-distills a stored session without persisting, diffs candidate lessons against stored ones (added / removed / unchanged), exits 1 on drift. Foundation for drift alarms and rollback.

## What changed

### Python
- `Makefile` — `type` target: `uv run mypy` → `uv run --extra dev mypy`
- `src/bsela/cli.py` — `status` command gains `--json` flag; new `replay` command wired to `replay_session()`
- `src/bsela/core/replay.py` *(new)* — `replay_session()`, `ReplayResult`, `LessonDiff`, `_diff_lessons()` with case/whitespace normalization
- `src/bsela/memory/store.py` — `list_lessons()` gains `session_id=` keyword filter (JOIN through `ErrorRecord`)
- `tests/test_replay.py` *(new)* — 8 tests covering all diff paths, normalization, CLI error exit
- `tests/test_cli_smoke.py`, `tests/test_cli_ingest.py` — 2 new tests for `status --json`

### TypeScript (MCP)
- `mcp/src/bsela-client.ts` — `StatusPayload` interface; `status()` returns `StatusPayload` via `--json`
- `mcp/src/index.ts` — re-exports `StatusPayload`
- `mcp/src/server-tools.ts` — `handleStatus` returns `structuredContent`
- `mcp/tests/*.test.ts` — stubs updated to `StatusPayload`; integration test prefers `~/.local/bin/bsela` over pyenv shims

### Docs
- `docs/roadmap.md` — P7 row updated to 🔄 scaffolded

## Test results

- Python: **171 passed** (`make check` green — ruff, mypy, pytest)
- TypeScript: **19 passed** (`pnpm check` green — prettier, eslint, tsc, vitest)

## Reviewer notes

- The `list_lessons(session_id=)` JOIN relies on `source_error_id` being non-null; lessons distilled without a matched error (rare edge) won't appear in per-session queries. A direct `session_id` column on `Lesson` would close this gap but is a schema migration — deferred to a follow-up.
- `bsela rollback` remains a stub (P7 second step).
- P6 dogfood gate (one real editor session via MCP) is still operator-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)