### PR TITLE
fix(replay): detect scope/confidence drift; remove 100-row lesson cap

### DIFF
--- a/src/bsela/core/replay.py
+++ b/src/bsela/core/replay.py
@@ -17,18 +17,21 @@ Usage:
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 from bsela.llm.client import LLMClient
 from bsela.llm.distiller import DistillationResult, distill_session
 from bsela.memory.models import Lesson
 from bsela.memory.store import get_session, list_lessons
 
+_CONFIDENCE_DRIFT_THRESHOLD = 0.1
+
 
 @dataclass(frozen=True)
 class LessonDiff:
     """One entry in the diff between stored and replayed lessons."""
 
-    kind: str  # "added" | "removed" | "unchanged"
+    kind: Literal["added", "removed", "unchanged", "changed"]
     rule: str
     confidence: float
     scope: str
@@ -49,15 +52,16 @@ class ReplayResult:
             return f"session {self.session_id}: judge rated healthy — no lessons produced"
         added = [d for d in self.diff if d.kind == "added"]
         removed = [d for d in self.diff if d.kind == "removed"]
+        changed = [d for d in self.diff if d.kind == "changed"]
         unchanged = [d for d in self.diff if d.kind == "unchanged"]
         parts = [f"session {self.session_id}: replay diff"]
         parts.append(
             f"  stored={len(self.stored_lessons)}"
             f"  replayed={len(self.replayed_lessons)}"
-            f"  +{len(added)} -{len(removed)} ={len(unchanged)}"
+            f"  +{len(added)} -{len(removed)} ~{len(changed)} ={len(unchanged)}"
         )
         for d in self.diff:
-            prefix = {"added": "+", "removed": "-", "unchanged": "="}[d.kind]
+            prefix = {"added": "+", "removed": "-", "unchanged": "=", "changed": "~"}[d.kind]
             parts.append(f"  {prefix} [{d.scope}] {d.rule} (conf={d.confidence:.2f})")
         return "\n".join(parts)
 
@@ -71,7 +75,12 @@ def _diff_lessons(
     stored: list[Lesson],
     replayed: list[Lesson],
 ) -> tuple[LessonDiff, ...]:
-    """Rule-level diff: exact match on normalised rule text."""
+    """Rule-level diff with scope/confidence drift detection.
+
+    Rules are matched on normalised text. When a rule matches, scope or a
+    confidence delta ≥ _CONFIDENCE_DRIFT_THRESHOLD produces "changed" rather
+    than "unchanged", so safety-gate-affecting replay differences surface.
+    """
     stored_rules = {_normalize(s.rule): s for s in stored}
     replayed_rules = {_normalize(r.rule): r for r in replayed}
 
@@ -79,8 +88,14 @@ def _diff_lessons(
     all_keys = stored_rules.keys() | replayed_rules.keys()
     for key in sorted(all_keys):
         if key in stored_rules and key in replayed_rules:
+            s = stored_rules[key]
             r = replayed_rules[key]
-            diffs.append(LessonDiff("unchanged", r.rule, r.confidence, r.scope))
+            scope_drifted = s.scope != r.scope
+            conf_drifted = abs(s.confidence - r.confidence) >= _CONFIDENCE_DRIFT_THRESHOLD
+            kind: Literal["unchanged", "changed"] = (
+                "changed" if (scope_drifted or conf_drifted) else "unchanged"
+            )
+            diffs.append(LessonDiff(kind, r.rule, r.confidence, r.scope))
         elif key in replayed_rules:
             r = replayed_rules[key]
             diffs.append(LessonDiff("added", r.rule, r.confidence, r.scope))
@@ -103,7 +118,7 @@ def replay_session(
     if session is None:
         raise LookupError(f"session not found: {session_id}")
 
-    stored = list_lessons(session_id=session_id)
+    stored = list_lessons(session_id=session_id, limit=None)
 
     result: DistillationResult = distill_session(
         session_id,

--- a/src/bsela/memory/store.py
+++ b/src/bsela/memory/store.py
@@ -179,7 +179,7 @@ def list_lessons(
     status: str | None = None,
     scope: str | None = None,
     session_id: str | None = None,
-    limit: int = 100,
+    limit: int | None = 100,
 ) -> list[Lesson]:
     stmt = select(Lesson).order_by(Lesson.created_at.desc())  # type: ignore[attr-defined]
     if status is not None:
@@ -190,7 +190,8 @@ def list_lessons(
         stmt = stmt.join(ErrorRecord, Lesson.source_error_id == ErrorRecord.id).where(  # type: ignore[arg-type]
             ErrorRecord.session_id == session_id
         )
-    stmt = stmt.limit(limit)
+    if limit is not None:
+        stmt = stmt.limit(limit)
     with session_scope() as s:
         return list(s.exec(stmt).all())
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import pytest
 from typer.testing import CliRunner
@@ -39,17 +40,22 @@ def _healthy_verdict() -> JudgeVerdict:
     )
 
 
-def _distill_response(rule: str = "Do not retry on the same error twice") -> DistillResponse:
+def _distill_response(
+    rule: str = "Do not retry on the same error twice",
+    *,
+    scope: Literal["project", "global"] = "project",
+    confidence: float = 0.88,
+) -> DistillResponse:
     return DistillResponse(
         status="ok",
-        confidence=0.88,
+        confidence=confidence,
         lessons=[
             LessonCandidate(
                 rule=rule,
                 why="loop detector flagged retries",
                 how_to_apply="switch strategy after second failure",
-                scope="project",
-                confidence=0.88,
+                scope=scope,
+                confidence=confidence,
                 evidence={},
             )
         ],
@@ -200,6 +206,93 @@ def test_replay_diff_normalization_ignores_case_and_whitespace(
     assert len(unchanged) >= 1
 
 
+def test_replay_scope_change_shows_changed(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    rule = "Do not retry on the same error twice"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=rule,
+            why="reason",
+            how_to_apply="action",
+            confidence=0.88,
+            status="pending",
+        )
+    )
+
+    result = replay_session(
+        session_id,
+        client=_fake_client(distill=_distill_response(rule, scope="global")),
+    )
+
+    changed = [d for d in result.diff if d.kind == "changed"]
+    assert any(d.rule == rule for d in changed), result.diff
+
+
+def test_replay_confidence_drift_shows_changed(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    rule = "Do not retry on the same error twice"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=rule,
+            why="reason",
+            how_to_apply="action",
+            confidence=0.60,
+            status="pending",
+        )
+    )
+
+    result = replay_session(
+        session_id,
+        client=_fake_client(distill=_distill_response(rule, confidence=0.88)),
+    )
+
+    changed = [d for d in result.diff if d.kind == "changed"]
+    assert any(d.rule == rule for d in changed), result.diff
+
+
+def test_replay_small_confidence_delta_shows_unchanged(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    rule = "Do not retry on the same error twice"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=rule,
+            why="reason",
+            how_to_apply="action",
+            confidence=0.82,
+            status="pending",
+        )
+    )
+
+    result = replay_session(
+        session_id,
+        client=_fake_client(distill=_distill_response(rule, confidence=0.88)),
+    )
+
+    unchanged = [d for d in result.diff if d.kind == "unchanged"]
+    assert any(d.rule == rule for d in unchanged), result.diff
+
+
 # ---- ReplayResult.summary() -------------------------------------------------
 
 
@@ -212,12 +305,14 @@ def test_summary_shows_session_id_and_counts() -> None:
         diff=(
             LessonDiff("added", "new rule", 0.9, "project"),
             LessonDiff("removed", "old rule", 0.7, "project"),
+            LessonDiff("changed", "drifted rule", 0.5, "global"),
         ),
     )
     summary = result.summary()
     assert "abc-123" in summary
     assert "+1" in summary
     assert "-1" in summary
+    assert "~1" in summary
 
 
 # ---- CLI bsela replay -------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses two [bot-reviewed gaps](https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/pull/1#discussion) in the P7 replay harness:

- **P1 fix** — `_diff_lessons` now emits `"changed"` when a matched rule has a scope change or a confidence delta ≥ 0.1. Previously, only rule-text changes surfaced as drift; scope/confidence shifts that affect safety gates (judge threshold, lesson gating) were silently classified as `"unchanged"`, letting `bsela replay` exit 0 on real drift.
- **P2 fix** — `list_lessons()` gains `limit: int | None = 100`. Passing `None` skips the SQL `LIMIT` clause. `replay_session` now calls it with `limit=None` so sessions with >100 stored lessons are fully diffed rather than comparing against a silently-truncated baseline.

## Changes

| File | Change |
|---|---|
| `src/bsela/core/replay.py` | `LessonDiff.kind` typed as `Literal[...]`; `_CONFIDENCE_DRIFT_THRESHOLD = 0.1`; `_diff_lessons` emits `"changed"` on scope/confidence drift; `summary()` shows `~N` changed count |
| `src/bsela/memory/store.py` | `list_lessons(limit: int \| None = 100)` — `None` omits `.limit()` clause |
| `tests/test_replay.py` | 3 new tests: scope change → `changed`, confidence drift ≥ 0.1 → `changed`, small delta → `unchanged`; updated summary test |

## Test results

174 passed (`make check` green — ruff, mypy, pytest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)