### PR TITLE
chore(community): add SECURITY, CONTRIBUTING, CHANGELOG, CODEOWNERS, issue templates, dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Default reviewer for everything in this repo.
+* @subkoks

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report something that isn't behaving as expected
+title: "bug: <short summary>"
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in what you can.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the bug. Include exact commands, output, or screenshots.
+      placeholder: "When I run X, I expected Y, but Z happened."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce.
+      placeholder: |
+        1. Run `bsela ...`
+        2. Observe `...`
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: BSELA version / commit
+      placeholder: "e.g. v0.3.1 or commit abcd123"
+  - type: input
+    id: host
+    attributes:
+      label: Agent host
+      placeholder: "Claude Code / Codex / Cursor / Windsurf / other"
+  - type: input
+    id: env
+    attributes:
+      label: OS + Python
+      placeholder: "e.g. macOS 26.4, Python 3.13.2"
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / context
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security disclosure
+    url: https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/security/advisories/new
+    about: Privately report a security issue (do not open a public issue).
+  - name: Question / discussion
+    url: https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/issues
+    about: Open a normal issue with the `question` label until Discussions is enabled.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: Suggest an enhancement or new capability
+title: "feat: <short summary>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What pain are you trying to remove? Why does the current state fall short?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the change. UX, API shape, examples welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # Python dependencies (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      python-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to BSELA are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Until 1.0, breaking changes are allowed in any minor release; they will be
+called out under a `Breaking` heading.
+
+## [Unreleased]
+
+### Added
+
+- Repository community-health files: `SECURITY.md`, `CONTRIBUTING.md`,
+  this `CHANGELOG.md`, `.github/CODEOWNERS`, `.github/ISSUE_TEMPLATE/*`,
+  and `.github/dependabot.yml`.
+
+[Unreleased]: https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/commits/main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to BSELA
+
+Thanks for considering a contribution. BSELA is a local control plane that
+learns from coding-AI sessions, so the project is intentionally small,
+local-first, and conservative about external dependencies.
+
+## Quick start
+
+```bash
+git clone https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI.git
+cd BEST-Self-Enhancement-Learning-AI
+
+# Python toolchain (recommended)
+uv sync          # install deps from pyproject.toml + uv.lock
+uv run pytest -q # run tests
+
+# Pre-flight checks
+make lint        # if available
+make test        # if available
+```
+
+## Workflow
+
+1. Open an issue first for non-trivial changes — alignment is faster than
+   re-architecture in review.
+2. Branch from `main` using a descriptive prefix:
+   - `feat/...` new feature
+   - `fix/...` bug fix
+   - `chore/...` tooling, refactor, infra
+   - `docs/...` documentation only
+3. Keep PRs focused: one logical change per PR.
+4. Update or add tests for behavior changes.
+5. Run `pytest` (and any TS tests under `mcp/`) before requesting review.
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/) where
+practical:
+
+```
+<type>(<scope>): <short summary>
+```
+
+Examples: `feat(hooks): add transcript redaction`,
+`fix(adapters): handle missing AGENTS.md`.
+
+## Code style
+
+- Python 3.13+; type hints on all public functions.
+- `ruff format` + `ruff check` for Python; Prettier for the TS in `mcp/`.
+- No silent breaking changes; flag with a `BREAKING:` footer in commit body.
+
+## Tests
+
+- `pytest` for Python; vitest for TypeScript MCP code.
+- Prefer fast unit tests; use the smallest fixture that proves the change.
+- Don't introduce mocks for things you can run for real cheaply (filesystem,
+  local sqlite, in-process MCP).
+
+## Reporting bugs and feature requests
+
+Use the issue templates: `Bug report` or `Feature request`. Security issues
+go through `SECURITY.md`, not the public tracker.
+
+## License
+
+By contributing you agree your work is licensed under the MIT License (see
+`LICENSE`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,45 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+BSELA is local-first software. Most issues should be reported as normal GitHub
+issues. **Do not** open a public issue for security-sensitive findings — for
+those, use GitHub's private vulnerability reporting:
+
+- <https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/security/advisories/new>
+
+If private reporting is unavailable for any reason, contact the maintainer
+through the Twitter/X handle linked from <https://github.com/subkoks>.
+
+Please include:
+
+- A description of the issue and the impact.
+- Steps to reproduce, ideally with a minimal proof of concept.
+- Affected version or commit SHA.
+- Your environment (OS, runtime versions, editor / agent host).
+
+## Scope
+
+In scope:
+
+- The `bsela` package and CLI.
+- Hooks, MCP server wiring, and adapters shipped from this repo.
+- Default configuration and example configs.
+
+Out of scope:
+
+- Third-party agent hosts (Claude Code, Codex, Cursor, Windsurf) themselves.
+- User-modified hooks or out-of-tree integrations.
+- Vulnerabilities that require a malicious local user with full filesystem
+  access, since BSELA is explicitly local-first.
+
+## Disclosure
+
+We aim to acknowledge a report within 7 days and to ship a fix or mitigation
+before public disclosure when feasible. Reporters are credited in release
+notes unless they request otherwise.
+
+## Supported versions
+
+BSELA is pre-1.0; only the latest `main` branch is actively supported. Older
+tags receive fixes only for the most recent release line.


### PR DESCRIPTION
## Summary
Bring BSELA up to a "100% community health" baseline and turn on automated dependency updates.

Files added:
- `SECURITY.md` — private vulnerability reporting policy + scope.
- `CONTRIBUTING.md` — quick start, branch naming, commit style, test guidance.
- `CHANGELOG.md` — Keep-a-Changelog seed; documents this PR under `[Unreleased]`.
- `.github/CODEOWNERS` — `* @subkoks`.
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/feature_request.yml`
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues; links to private security advisory form.
- `.github/dependabot.yml` — `uv` ecosystem (pyproject.toml + uv.lock) and `github-actions`, weekly Mondays UTC, grouped minor/patch updates.

## Why
Pre-PR community health: 57%. No SECURITY, CONTRIBUTING, CODEOWNERS, issue templates, or dependabot. This PR closes those in one shot. Bumps health to ~100% and starts a weekly dependency-update cadence with the same shape as `stake-mirrors-ping` and `agents-md`.

## Settings (separately, no PR needed)
- Enabled `allow_auto_merge` (delete-branch-on-merge was already on).

## Test plan
- [ ] Repo Insights → Community Standards shows ~100%.
- [ ] "Open new issue" UI shows Bug + Feature options (blank disabled).
- [ ] Security link in issue template chooser opens the private advisory form.
- [ ] After merge, a Dependabot run appears in the Actions / Insights → Dependency graph view (allow up to 24h for the first scan).

## Notes
- Used `package-ecosystem: uv` to honor `uv.lock`. If your install of Dependabot reports it as unsupported, swap to `pip` (auto-detects `pyproject.toml`).
- No workflow files touched in this PR.

🤖 Authored by Lead GitHub Engineer agent (Claude Code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds GitHub/community configuration and documentation only, with no runtime code changes; main impact is workflow/process (issue intake and automated dependency PRs).
> 
> **Overview**
> Adds repository community/maintenance scaffolding: `SECURITY.md`, `CONTRIBUTING.md`, and a seeded `CHANGELOG.md` documenting these additions under `[Unreleased]`.
> 
> Configures GitHub project hygiene by introducing `.github/CODEOWNERS`, issue templates (bug/feature) with blank issues disabled and a private security reporting link, and `.github/dependabot.yml` to open weekly grouped minor/patch dependency update PRs for `uv` and GitHub Actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a89d1e80054f8bd2ed9e29a0c77b963dd47bd59. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->