### PR TITLE
chore(community): add missing security and PR baseline files

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+## Summary
+- 
+
+## Why
+- 
+
+## Changes
+- 
+
+## Test plan
+- [ ] Local checks pass
+- [ ] Behavior verified
+
+## Risks
+- 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do not open public issues for security reports.
+
+Report privately via GitHub Security Advisories:
+1. Open the repository.
+2. Go to **Security**.
+3. Click **Report a vulnerability**.
+4. Include reproduction steps, impact, and any proof-of-concept.
+
+You will receive an acknowledgement as soon as possible, and we will coordinate remediation and disclosure timing.


### PR DESCRIPTION
## Summary
- add `.github/SECURITY.md`
- add `.github/PULL_REQUEST_TEMPLATE.md`

## Why
These were the remaining community-health baseline gaps for this repo.

## Notes
- `CONTRIBUTING.md` already exists and was not modified.

## Test plan
- [ ] Verify files render in default branch after merge
- [ ] Confirm template appears when opening a new PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds GitHub community-health metadata only; no runtime code or behavior changes.
> 
> **Overview**
> Adds a default `.github/PULL_REQUEST_TEMPLATE.md` to standardize PR descriptions (summary/why/changes/test plan/risks).
> 
> Adds `.github/SECURITY.md` documenting the security policy and directing vulnerability reports to GitHub Security Advisories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09fc04a89eb0e9138e7c39ee24f221d9e02553b6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->