### PR TITLE
test(cli): lock replays list json empty and drift-only arrays

### DIFF
--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -439,6 +439,25 @@ def test_cli_replays_list_empty(tmp_bsela_home: Path) -> None:
     assert "no entries" in result.stdout
 
 
+def test_cli_replays_list_json_empty_store_returns_empty_array(tmp_bsela_home: Path) -> None:
+    result = CliRunner().invoke(app, ["replays", "list", "--json"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
+def test_cli_replays_list_json_drift_only_returns_empty_when_only_non_drift_records(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    sid = list_sessions(status="captured")[0].id
+    save_replay_record(
+        ReplayRecord(session_id=sid, had_drift=False, added_count=0, removed_count=0)
+    )
+    result = CliRunner().invoke(app, ["replays", "list", "--json", "--drift-only"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
 def test_cli_replays_list_shows_records(tmp_bsela_home: Path, sample_clean_session: Path) -> None:
     ingest_file(sample_clean_session)
     sid = list_sessions(status="captured")[0].id


### PR DESCRIPTION
Adds contract tests for `bsela replays list --json`: empty store returns `[]`, and `--drift-only` returns `[]` when only non-drift replay rows exist. Complements existing keyset test for non-empty JSON rows. No runtime or MCP changes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds CLI contract tests only; no runtime code changes. Low risk aside from potential future test brittleness if output formatting changes.
> 
> **Overview**
> Adds new contract tests for `bsela replays list --json` to ensure an empty replay store prints `[]`, and that `--drift-only` yields `[]` when only non-drift `ReplayRecord`s exist.
> 
> This complements the existing non-empty JSON output test and tightens expected machine-readable CLI behavior for edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f78c9d456244d5a91afe1e6e5dbc4dde91e85535. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->