### PR TITLE
test(cli): lock route keys and filtered-json empty-array edges

### DIFF
--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -207,6 +207,14 @@ def test_review_list_json_empty_store_returns_empty_array(tmp_bsela_home: Path) 
     assert json.loads(result.stdout) == []
 
 
+def test_review_list_json_status_mismatch_returns_empty_array(tmp_bsela_home: Path) -> None:
+    """``--status proposed`` with only pending rows must serialize as []."""
+    _project_lesson()
+    result = CliRunner().invoke(app, ["review", "list", "--json", "--status", "proposed"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
 def test_review_list_json_track_hits_persists_after_payload(tmp_bsela_home: Path) -> None:
     lesson = _project_lesson()
     result = CliRunner().invoke(app, ["review", "list", "--json", "--track-hits", "--limit", "1"])

--- a/tests/test_cli_route_audit.py
+++ b/tests/test_cli_route_audit.py
@@ -31,6 +31,32 @@ def test_route_json_mode_returns_machine_payload() -> None:
     assert "refactor" in payload["matched_keywords"]
 
 
+def test_route_json_locks_top_level_keys() -> None:
+    result = CliRunner().invoke(app, ["route", "plan the P5 rollout", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert sorted(payload.keys()) == [
+        "confidence",
+        "matched_keywords",
+        "model",
+        "reason",
+        "task_class",
+    ]
+
+
+def test_route_json_matched_keywords_empty_when_no_bucket_matches() -> None:
+    """Neutral text must not invent keywords; JSON still lists the key as []."""
+    result = CliRunner().invoke(
+        app,
+        ["route", "qwertyuiop asdfghjkl zxcvbnm typography neutral", "--json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["task_class"] == "builder"
+    assert payload["confidence"] == 0.5
+    assert payload["matched_keywords"] == []
+
+
 def test_route_empty_task_falls_back_to_default() -> None:
     result = CliRunner().invoke(app, ["route", "   "])
     assert result.exit_code == 0

--- a/tests/test_cli_sessions.py
+++ b/tests/test_cli_sessions.py
@@ -267,6 +267,13 @@ def test_sessions_list_json_status_filter(tmp_bsela_home: Path) -> None:
     assert all(r["status"] == "quarantined" for r in rows)
 
 
+def test_sessions_list_json_quarantined_empty_when_only_captured(tmp_bsela_home: Path) -> None:
+    ingest_file(FIXTURES / "clean.jsonl")
+    result = CliRunner().invoke(app, ["sessions", "list", "--json", "--status", "quarantined"])
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout) == []
+
+
 def test_errors_list_json_empty(tmp_bsela_home: Path) -> None:
     """errors list --json returns an empty array when no errors exist."""
     result = CliRunner().invoke(app, ["errors", "list", "--json"])
@@ -321,3 +328,19 @@ def test_errors_list_json_session_filter(tmp_bsela_home: Path) -> None:
     rows = json.loads(result.stdout)
     assert all(r["session_id"] == target_id for r in rows)
     assert len(rows) == 1
+
+
+def test_errors_list_json_session_filter_empty_when_session_has_no_errors(
+    tmp_bsela_home: Path,
+) -> None:
+    ingest_file(FIXTURES / "clean.jsonl")
+    ingest_file(FIXTURES / "user-correction.jsonl")
+    without_errors: str | None = None
+    for sess in list_sessions(status="captured", limit=10):
+        if not list_errors(session_id=sess.id, limit=None):
+            without_errors = sess.id
+            break
+    assert without_errors is not None
+    result = CliRunner().invoke(app, ["errors", "list", "--json", "--session-id", without_errors])
+    assert result.exit_code == 0, result.stdout
+    assert json.loads(result.stdout) == []

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -92,6 +92,22 @@ def test_lessons_json_with_empty_store_returns_empty_array(tmp_bsela_home: Path)
     assert payload == []
 
 
+def test_lessons_json_status_mismatch_returns_empty_array(tmp_bsela_home: Path) -> None:
+    save_lesson(
+        Lesson(
+            scope="project",
+            rule="r",
+            why="w",
+            how_to_apply="h",
+            confidence=0.9,
+            status="pending",
+        )
+    )
+    result = CliRunner().invoke(app, ["lessons", "--json", "--status", "proposed"])
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == []
+
+
 def test_lessons_json_locks_item_keys(tmp_bsela_home: Path, sample_clean_session: Path) -> None:
     ingest_file(sample_clean_session)
     session_id = list_sessions()[0].id


### PR DESCRIPTION
Extends JSON contract coverage:

- `route --json`: stable top-level keyset; neutral task yields `matched_keywords: []` and default builder fallthrough.
- `review list --json --status proposed` with only pending lessons → `[]`.
- `lessons --json --status proposed` alias → `[]`.
- `sessions list --json --status quarantined` with only captured sessions → `[]`.
- `errors list --json --session-id` for a session with zero error rows → `[]`.

No production code changes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are test-only and focus on asserting JSON output shape and empty-filter edge cases, with no production code modifications.
> 
> **Overview**
> Adds CLI regression tests that **lock down JSON contracts** and edge cases across commands.
> 
> Specifically asserts `route --json` emits a stable top-level keyset and returns `matched_keywords: []` when nothing matches, and verifies that filtered `--json` list commands (`review list`, `lessons`, `sessions list`, `errors list`) serialize as `[]` when filters exclude all rows (status mismatches or sessions with no errors).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3bbeeb1aa98300cb9b547351c40c7d55cb563ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->