### PR TITLE
test(cli): lock route json for whitespace-only task

### DIFF
--- a/tests/test_cli_route_audit.py
+++ b/tests/test_cli_route_audit.py
@@ -65,6 +65,16 @@ def test_route_empty_task_falls_back_to_default() -> None:
     assert "0.50" in result.stdout
 
 
+def test_route_empty_task_json_payload_matches_fallthrough() -> None:
+    result = CliRunner().invoke(app, ["route", "   ", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["task_class"] == "builder"
+    assert payload["confidence"] == 0.5
+    assert payload["matched_keywords"] == []
+    assert "empty" in payload["reason"].lower()
+
+
 def test_audit_writes_markdown_when_store_empty(tmp_bsela_home: Path) -> None:
     result = CliRunner().invoke(app, ["audit"])
     # Empty store, no alerts → exit 0, file written.


### PR DESCRIPTION
Adds `route "   " --json` coverage so the default fallthrough (builder, confidence 0.5, empty `matched_keywords`, empty-task reason) stays stable alongside existing route JSON tests.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that adds coverage for a whitespace-only `route` input in JSON mode, with no production logic modifications.
> 
> **Overview**
> Adds a new CLI smoke test ensuring `bsela route "   " --json` returns the same default fallthrough as the text output (class `builder`, confidence `0.5`, empty `matched_keywords`, and an *empty-task* reason), keeping the machine payload stable for whitespace-only tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee01c5ae72f3991e871ba7071a60b9840b857ae9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->