### PR TITLE
chore(ci): add pnpm-aware dependabot entry for mcp workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,28 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  # MCP TypeScript workspace (pnpm-aware via npm ecosystem on pnpm-lock.yaml).
+  # Without this entry, security advisories on transitive deps trigger the
+  # default npm_and_yarn updater and fail with NoChangeError because they
+  # cannot rewrite a pnpm lockfile.
+  - package-ecosystem: "npm"
+    directory: "/mcp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "mcp"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      mcp-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

The repo's Dependabot Updates workflow has been failing repeatedly on `main` (~6 failures over the last 48h). Root cause is a security advisory targeting `fast-uri` in `mcp/pnpm-lock.yaml`:

- `fast-uri` is a transitive dep (only present in `mcp/pnpm-lock.yaml`, not in `mcp/package.json`).
- Without an npm ecosystem entry pointing at `/mcp`, Dependabot's security path falls into the default `npm_and_yarn` updater, which cannot rewrite a pnpm lockfile and exits with `NoChangeError`.

This change adds an `npm` ecosystem entry for `/mcp` so Dependabot uses the pnpm-aware updater (auto-detected from `pnpm-lock.yaml`).

## Files changed

- `.github/dependabot.yml` — new ecosystem block for `/mcp` (weekly, scoped commit prefix, grouped minor/patch).

## Test plan

- [x] `python -c "yaml.safe_load(...)"` confirms valid YAML.
- [ ] After merge, watch the next Dependabot Updates run on `main` — should either succeed or open a real PR for `fast-uri` instead of failing.
- [ ] Pre-existing security advisories list (8 reported by GitHub) becomes triageable through new PRs.

## Notes

- Other CI workflows (`ci.yml`, `mcp.yml`, `audit.yml`, `claude.yml`) are unchanged.
- This is the smallest possible fix. If the GitHub-side advisories still cannot rewrite the lockfile after this lands, the next move is an explicit `ignore:` for transitive-only deps.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change to Dependabot update settings; main impact is how dependency update PRs are generated for the `/mcp` workspace.
> 
> **Overview**
> Adds a new Dependabot `npm` update configuration for the `/mcp` workspace so Dependabot can update `pnpm-lock.yaml` (including transitive security advisory fixes) instead of falling back to the `npm_and_yarn` updater.
> 
> The new entry runs weekly, applies `dependencies`/`mcp` labels, uses scoped `chore` commit messages, and groups minor/patch updates into `mcp-minor-patch` PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e26feba7de5277339067cd92089eecf4fa2eed. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->