### PR TITLE
chore(security): pin patched fast-uri/ip-address/hono via pnpm overrides

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -44,5 +44,12 @@
     "prettier": "^3.4.2",
     "typescript": "^6.0.3",
     "vitest": "^3.0.0"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-uri": ">=3.1.2",
+      "ip-address": ">=10.1.1",
+      "hono": ">=4.12.18"
+    }
   }
 }

--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-uri: '>=3.1.2'
+  ip-address: '>=10.1.1'
+  hono: '>=4.12.18'
+
 importers:
 
   .:
@@ -237,7 +242,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.18'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -778,8 +783,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -857,8 +862,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
     engines: {node: '>=16.9.0'}
 
   http-errors@2.0.1:
@@ -888,8 +893,8 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -1469,9 +1474,9 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.15)':
+  '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
-      hono: 4.12.15
+      hono: 4.12.18
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1493,7 +1498,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.15)
+      '@hono/node-server': 1.19.14(hono@4.12.18)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1503,7 +1508,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.15
+      hono: 4.12.18
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -1761,7 +1766,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -2006,7 +2011,7 @@ snapshots:
   express-rate-limit@8.4.1(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -2047,7 +2052,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2123,7 +2128,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.15: {}
+  hono@4.12.18: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -2150,7 +2155,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

Resolves all 8 open Dependabot advisories on `mcp/pnpm-lock.yaml`:

| Severity | Package | Vulnerability | Fix |
|---|---|---|---|
| high | fast-uri | host confusion via percent-encoded authority | >=3.1.2 |
| high | fast-uri | path traversal via percent-encoded dot segments | >=3.1.2 |
| medium | ip-address | XSS in Address6 HTML-emitting methods | >=10.1.1 |
| medium | hono | bodyLimit() bypass for chunked / unknown-length | >=4.12.18 |
| medium | hono | jsx Unvalidated tag names allow HTML injection | >=4.12.18 |
| medium | hono | Cache middleware ignores Vary: Authorization/Cookie | >=4.12.18 |
| medium | hono | CSS Declaration Injection in JSX SSR | >=4.12.18 |
| low | hono | JWT verify() improper NumericDate validation | >=4.12.18 |

All three packages are transitive deps pulled in via `@modelcontextprotocol/sdk`:
- `@modelcontextprotocol/sdk > ajv > fast-uri`
- `@modelcontextprotocol/sdk > express-rate-limit > ip-address`
- `@modelcontextprotocol/sdk > ... > hono`

## Approach

Add a `pnpm.overrides` block in `mcp/package.json` to force the patched versions. This is more surgical than bumping `@modelcontextprotocol/sdk` itself, which is currently at the latest version (`^1.29.0`) and would risk breaking changes from a major SDK rev when one becomes available.

## Files changed

- `mcp/package.json` — added `pnpm.overrides` block.
- `mcp/pnpm-lock.yaml` — regenerated with patched transitive versions.

## Test plan

- [x] `pnpm audit --prod` reports `No known vulnerabilities found`.
- [x] `pnpm check` passes 59/59 (lint, typecheck, all tests including CLI<->MCP parity).
- [ ] Post-merge, GitHub Dependabot security tab should show all 8 advisories closed.

## Notes

- No code changes — overrides only affect lockfile resolution.
- Override versions use `>=` ranges to allow future patch bumps without manual updates.
- If `@modelcontextprotocol/sdk` later bundles patched transitives directly, the overrides become redundant and can be removed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: dependency-resolution-only change to force patched transitive versions; main risk is unexpected behavior changes from upstream patch releases.
> 
> **Overview**
> Adds `pnpm.overrides` in `mcp/package.json` to force patched transitive versions of `fast-uri`, `ip-address`, and `hono`.
> 
> Regenerates `mcp/pnpm-lock.yaml` so the resolved graph uses the newer patched versions (including updating `@hono/node-server`’s `hono` peer resolution) without changing application code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ba5742de23cd55b84b3e8012930d35a753d8055. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->