### PR TITLE
fix(core): semantic replay diff via Jaccard similarity

### DIFF
--- a/src/bsela/core/replay.py
+++ b/src/bsela/core/replay.py
@@ -20,9 +20,15 @@ from dataclasses import dataclass
 from typing import Literal
 
 from bsela.llm.client import LLMClient
-from bsela.llm.distiller import DistillationResult, distill_session
+from bsela.llm.distiller import (
+    DistillationResult,
+    _jaccard,
+    _tokens,
+    distill_session,
+)
 from bsela.memory.models import Lesson, ReplayRecord
 from bsela.memory.store import get_session, list_lessons, save_replay_record
+from bsela.utils.config import load_thresholds
 
 _CONFIDENCE_DRIFT_THRESHOLD = 0.1
 
@@ -75,32 +81,77 @@ def _diff_lessons(
     stored: list[Lesson],
     replayed: list[Lesson],
 ) -> tuple[LessonDiff, ...]:
-    """Rule-level diff with scope/confidence drift detection.
+    """Semantic rule-level diff with scope/confidence drift detection.
 
-    Rules are matched on normalised text. When a rule matches, scope or a
-    confidence delta ≥ _CONFIDENCE_DRIFT_THRESHOLD produces "changed" rather
-    than "unchanged", so safety-gate-affecting replay differences surface.
+    Rules are matched via Jaccard token similarity using the same
+    ``dedupe.similarity_threshold`` that the distiller applies — so paraphrases
+    of the same rule pair as ``unchanged``/``changed`` rather than inflating
+    drift with ``+`` and ``-`` rows. First, exact normalised matches are paired
+    (cheap and stable); then each remaining stored lesson greedily pairs with
+    the most-similar remaining replayed lesson above threshold. Anything left
+    over is genuinely added/removed.
+
+    Why: temperature=0 + seed cannot fully stabilise paraphrasing across
+    Anthropic (no seed support) and judge non-determinism. Aligning the diff
+    metric with the dedupe metric prevents replay drift from firing on noise
+    that would have been deduped at persist time anyway.
     """
-    stored_rules = {_normalize(s.rule): s for s in stored}
-    replayed_rules = {_normalize(r.rule): r for r in replayed}
+    threshold = load_thresholds().dedupe.similarity_threshold
+
+    stored_remaining = list(stored)
+    replayed_remaining = list(replayed)
+    pairs: list[tuple[Lesson, Lesson]] = []
+
+    # Pass 1: exact normalised matches — fast and stable.
+    norm_replayed: dict[str, int] = {}
+    for idx, r in enumerate(replayed_remaining):
+        norm_replayed.setdefault(_normalize(r.rule), idx)
+    matched_stored: set[int] = set()
+    matched_replayed: set[int] = set()
+    for s_idx, s in enumerate(stored_remaining):
+        r_idx = norm_replayed.get(_normalize(s.rule))
+        if r_idx is not None and r_idx not in matched_replayed:
+            pairs.append((s, replayed_remaining[r_idx]))
+            matched_stored.add(s_idx)
+            matched_replayed.add(r_idx)
+
+    # Pass 2: greedy semantic match on remaining — best Jaccard above threshold.
+    leftover_stored = [s for i, s in enumerate(stored_remaining) if i not in matched_stored]
+    leftover_replayed_idx = [i for i in range(len(replayed_remaining)) if i not in matched_replayed]
+    replayed_used: set[int] = set()
+    stored_used: set[int] = set()
+    scored: list[tuple[float, int, int]] = []
+    for ls_idx, s in enumerate(leftover_stored):
+        s_toks = _tokens(s.rule)
+        for r_idx in leftover_replayed_idx:
+            r = replayed_remaining[r_idx]
+            sim = _jaccard(s_toks, _tokens(r.rule))
+            if sim >= threshold:
+                scored.append((sim, ls_idx, r_idx))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    for _sim, ls_idx, r_idx in scored:
+        if ls_idx in stored_used or r_idx in replayed_used:
+            continue
+        pairs.append((leftover_stored[ls_idx], replayed_remaining[r_idx]))
+        stored_used.add(ls_idx)
+        replayed_used.add(r_idx)
+
+    paired_stored = {id(s) for s, _ in pairs}
+    paired_replayed = {id(r) for _, r in pairs}
 
     diffs: list[LessonDiff] = []
-    all_keys = stored_rules.keys() | replayed_rules.keys()
-    for key in sorted(all_keys):
-        if key in stored_rules and key in replayed_rules:
-            s = stored_rules[key]
-            r = replayed_rules[key]
-            scope_drifted = s.scope != r.scope
-            conf_drifted = abs(s.confidence - r.confidence) >= _CONFIDENCE_DRIFT_THRESHOLD
-            kind: Literal["unchanged", "changed"] = (
-                "changed" if (scope_drifted or conf_drifted) else "unchanged"
-            )
-            diffs.append(LessonDiff(kind, r.rule, r.confidence, r.scope))
-        elif key in replayed_rules:
-            r = replayed_rules[key]
+    for s, r in pairs:
+        scope_drifted = s.scope != r.scope
+        conf_drifted = abs(s.confidence - r.confidence) >= _CONFIDENCE_DRIFT_THRESHOLD
+        kind: Literal["unchanged", "changed"] = (
+            "changed" if (scope_drifted or conf_drifted) else "unchanged"
+        )
+        diffs.append(LessonDiff(kind, r.rule, r.confidence, r.scope))
+    for r in replayed_remaining:
+        if id(r) not in paired_replayed:
             diffs.append(LessonDiff("added", r.rule, r.confidence, r.scope))
-        else:
-            s = stored_rules[key]
+    for s in stored_remaining:
+        if id(s) not in paired_stored:
             diffs.append(LessonDiff("removed", s.rule, s.confidence, s.scope))
     return tuple(diffs)
 

--- a/src/bsela/core/replay.py
+++ b/src/bsela/core/replay.py
@@ -77,6 +77,55 @@ def _normalize(rule: str) -> str:
     return " ".join(rule.lower().split())
 
 
+def _pair_exact(
+    stored: list[Lesson], replayed: list[Lesson]
+) -> tuple[list[tuple[Lesson, Lesson]], set[int], set[int]]:
+    """First-pass exact normalised match: cheap and stable."""
+    norm_replayed: dict[str, int] = {}
+    for idx, r in enumerate(replayed):
+        norm_replayed.setdefault(_normalize(r.rule), idx)
+    pairs: list[tuple[Lesson, Lesson]] = []
+    matched_stored: set[int] = set()
+    matched_replayed: set[int] = set()
+    for s_idx, s in enumerate(stored):
+        r_idx = norm_replayed.get(_normalize(s.rule))
+        if r_idx is not None and r_idx not in matched_replayed:
+            pairs.append((s, replayed[r_idx]))
+            matched_stored.add(s_idx)
+            matched_replayed.add(r_idx)
+    return pairs, matched_stored, matched_replayed
+
+
+def _pair_semantic(
+    stored: list[Lesson],
+    replayed: list[Lesson],
+    skip_stored: set[int],
+    skip_replayed: set[int],
+    threshold: float,
+) -> list[tuple[Lesson, Lesson]]:
+    """Second-pass: greedy Jaccard match on remaining lessons above ``threshold``."""
+    leftover_stored = [(i, s) for i, s in enumerate(stored) if i not in skip_stored]
+    leftover_replayed = [(i, r) for i, r in enumerate(replayed) if i not in skip_replayed]
+    scored: list[tuple[float, int, int]] = []
+    for s_idx, s in leftover_stored:
+        s_toks = _tokens(s.rule)
+        for r_idx, r in leftover_replayed:
+            sim = _jaccard(s_toks, _tokens(r.rule))
+            if sim >= threshold:
+                scored.append((sim, s_idx, r_idx))
+    scored.sort(key=lambda x: x[0], reverse=True)
+    used_stored: set[int] = set()
+    used_replayed: set[int] = set()
+    pairs: list[tuple[Lesson, Lesson]] = []
+    for _sim, s_idx, r_idx in scored:
+        if s_idx in used_stored or r_idx in used_replayed:
+            continue
+        pairs.append((stored[s_idx], replayed[r_idx]))
+        used_stored.add(s_idx)
+        used_replayed.add(r_idx)
+    return pairs
+
+
 def _diff_lessons(
     stored: list[Lesson],
     replayed: list[Lesson],
@@ -97,44 +146,9 @@ def _diff_lessons(
     that would have been deduped at persist time anyway.
     """
     threshold = load_thresholds().dedupe.similarity_threshold
-
-    stored_remaining = list(stored)
-    replayed_remaining = list(replayed)
-    pairs: list[tuple[Lesson, Lesson]] = []
-
-    # Pass 1: exact normalised matches — fast and stable.
-    norm_replayed: dict[str, int] = {}
-    for idx, r in enumerate(replayed_remaining):
-        norm_replayed.setdefault(_normalize(r.rule), idx)
-    matched_stored: set[int] = set()
-    matched_replayed: set[int] = set()
-    for s_idx, s in enumerate(stored_remaining):
-        r_idx = norm_replayed.get(_normalize(s.rule))
-        if r_idx is not None and r_idx not in matched_replayed:
-            pairs.append((s, replayed_remaining[r_idx]))
-            matched_stored.add(s_idx)
-            matched_replayed.add(r_idx)
-
-    # Pass 2: greedy semantic match on remaining — best Jaccard above threshold.
-    leftover_stored = [s for i, s in enumerate(stored_remaining) if i not in matched_stored]
-    leftover_replayed_idx = [i for i in range(len(replayed_remaining)) if i not in matched_replayed]
-    replayed_used: set[int] = set()
-    stored_used: set[int] = set()
-    scored: list[tuple[float, int, int]] = []
-    for ls_idx, s in enumerate(leftover_stored):
-        s_toks = _tokens(s.rule)
-        for r_idx in leftover_replayed_idx:
-            r = replayed_remaining[r_idx]
-            sim = _jaccard(s_toks, _tokens(r.rule))
-            if sim >= threshold:
-                scored.append((sim, ls_idx, r_idx))
-    scored.sort(key=lambda x: x[0], reverse=True)
-    for _sim, ls_idx, r_idx in scored:
-        if ls_idx in stored_used or r_idx in replayed_used:
-            continue
-        pairs.append((leftover_stored[ls_idx], replayed_remaining[r_idx]))
-        stored_used.add(ls_idx)
-        replayed_used.add(r_idx)
+    exact_pairs, matched_s, matched_r = _pair_exact(stored, replayed)
+    semantic_pairs = _pair_semantic(stored, replayed, matched_s, matched_r, threshold)
+    pairs = exact_pairs + semantic_pairs
 
     paired_stored = {id(s) for s, _ in pairs}
     paired_replayed = {id(r) for _, r in pairs}
@@ -147,12 +161,16 @@ def _diff_lessons(
             "changed" if (scope_drifted or conf_drifted) else "unchanged"
         )
         diffs.append(LessonDiff(kind, r.rule, r.confidence, r.scope))
-    for r in replayed_remaining:
-        if id(r) not in paired_replayed:
-            diffs.append(LessonDiff("added", r.rule, r.confidence, r.scope))
-    for s in stored_remaining:
-        if id(s) not in paired_stored:
-            diffs.append(LessonDiff("removed", s.rule, s.confidence, s.scope))
+    diffs.extend(
+        LessonDiff("added", r.rule, r.confidence, r.scope)
+        for r in replayed
+        if id(r) not in paired_replayed
+    )
+    diffs.extend(
+        LessonDiff("removed", s.rule, s.confidence, s.scope)
+        for s in stored
+        if id(s) not in paired_stored
+    )
     return tuple(diffs)
 
 

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -214,6 +214,45 @@ def test_replay_diff_normalization_ignores_case_and_whitespace(
     assert len(unchanged) >= 1
 
 
+def test_replay_paraphrase_pairs_as_unchanged(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    """Two paraphrases of the same rule pair via Jaccard-similarity rather than inflating +/-."""
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+
+    stored_rule = (
+        "Validate tool-invocation arguments to the expected types before "
+        "the call, especially numeric parameters as numbers, not strings."
+    )
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=stored_rule,
+            why="r",
+            how_to_apply="a",
+            confidence=0.85,
+            status="approved",
+        )
+    )
+
+    paraphrase = (
+        "Validate and coerce tool-invocation arguments to the expected types "
+        "before the call, especially numeric parameters as numbers, not strings."
+    )
+    result = replay_session(
+        session_id,
+        client=_fake_client(distill=_distill_response(paraphrase, confidence=0.85)),
+    )
+
+    kinds = {d.kind for d in result.diff}
+    assert "added" not in kinds, result.diff
+    assert "removed" not in kinds, result.diff
+    assert any(d.kind == "unchanged" for d in result.diff)
+
+
 def test_replay_scope_change_shows_changed(
     tmp_bsela_home: Path, sample_clean_session: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- Replay drift was firing on pure paraphrase noise: stored "Stop retrying Read on missing path after first ENOENT" vs. replayed "Don't retry Read after the first ENOENT" produced one removed + one added even though the distiller's own dedupe gate (`thresholds.dedupe.similarity_threshold`) would have treated them as the same rule.
- Aligns the replay diff metric with the dedupe metric so the alarm only fires on real drift (new rules, missing rules, scope shifts, confidence deltas ≥ 0.1).
- Two-pass pairing extracted into `_pair_exact` (cheap normalised match) and `_pair_semantic` (greedy best-Jaccard above threshold), reusing `_jaccard`/`_tokens` from the distiller so future tweaks stay in one place.
- Adds `test_replay_paraphrase_pairs_as_unchanged` to lock the behaviour.

## Why now
PR #34 (`temperature=0` + `seed=42`) didn't clear the replay drift alarm; Anthropic ignores `seed` and the judge verdict is itself stochastic, so paraphrasing keeps inflating drift. This PR fixes the metric so it stops false-firing on noise the distiller would already dedupe.

## Follow-up (not in this PR)
After landing, replay 7 sessions and re-checking `bsela audit --weekly` shows the model now emits **0 candidates on replay** for sessions that originally yielded 1–3 (so drift becomes pure `-N` removals). That's a separate issue: under temp=0 the distiller is suppressing candidates entirely, likely because `recent_lessons` in the prompt context steers it to "already covered". Worth investigating in the next session — track how many lessons the distiller emits per session before vs. after #34.

## Test plan
- [x] `uv run pytest tests/test_replay.py -q` — 24 pass
- [x] `uv run pytest -q` — 417 pass
- [x] `uv run ruff check src/bsela/core/replay.py tests/test_replay.py` — clean
- [x] `uv run mypy src/bsela/core/replay.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how replay drift is computed by pairing lessons semantically using the configurable `dedupe.similarity_threshold`, which can materially alter drift alarms and persisted replay records. Risk is moderate due to heuristic matching/greedy pairing and reliance on config thresholds, but scope is limited to replay diffing and tests cover paraphrase behavior.
> 
> **Overview**
> Updates the replay harness to **diff stored vs replayed lessons semantically** instead of strict normalized-text matching, reducing false drift from paraphrased rules.
> 
> `_diff_lessons` now does a two-pass pairing (`_pair_exact` then `_pair_semantic`) using the distiller’s `_tokens`/`_jaccard` and `thresholds.dedupe.similarity_threshold`, and only emits `added`/`removed` for truly unmatched lessons while still flagging scope or ≥0.1 confidence drift as `changed`.
> 
> Adds a regression test ensuring paraphrased rules pair as `unchanged` rather than producing `+/-` noise.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ded20b58ddc84ff466389c5d8aa3ecf2f5d45b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->