### PR TITLE
fix(core): stabilize replay drift signal and sqlite lifecycle

### DIFF
--- a/src/bsela/core/auditor.py
+++ b/src/bsela/core/auditor.py
@@ -76,7 +76,12 @@ class DriftSnapshot:
 
 @dataclass(frozen=True)
 class ReplayDriftSnapshot:
-    """Drift rate computed from persisted ``bsela replay`` outcomes (P7)."""
+    """Drift rate computed from persisted ``bsela replay`` outcomes (P7).
+
+    One replay row is a point-in-time result. To avoid historical tuning noise
+    pinning the alert indefinitely, the audit uses only the latest replay row
+    per session within the selected window.
+    """
 
     sessions_replayed: int
     sessions_with_drift: int
@@ -218,6 +223,12 @@ def build_audit(
             ).all()
         )
 
+    latest_replay_by_session: dict[str, ReplayRecord] = {}
+    for record in replay_records:
+        current = latest_replay_by_session.get(record.session_id)
+        if current is None or record.replayed_at > current.replayed_at:
+            latest_replay_by_session[record.session_id] = record
+
     sessions_quarantined = sum(1 for sess in sessions if sess.status == "quarantined")
 
     cost_total = round(sum(m.cost_usd for m in metrics), 6)
@@ -236,8 +247,8 @@ def build_audit(
     )
 
     replay_drift_snapshot = ReplayDriftSnapshot(
-        sessions_replayed=len(replay_records),
-        sessions_with_drift=sum(1 for r in replay_records if r.had_drift),
+        sessions_replayed=len(latest_replay_by_session),
+        sessions_with_drift=sum(1 for r in latest_replay_by_session.values() if r.had_drift),
         threshold=cfg.audit.replay_drift_threshold,
     )
 

--- a/src/bsela/core/replay.py
+++ b/src/bsela/core/replay.py
@@ -186,6 +186,10 @@ def replay_session(
     to the ``replay_records`` table so ``bsela audit`` can compute a drift rate
     over a rolling window without re-invoking the LLM.
 
+    If the session already has stored lessons, replay forces distillation even
+    when the judge now marks the session as healthy. This keeps replay drift
+    focused on lesson stability instead of judge-gating variance.
+
     Raises ``LookupError`` if ``session_id`` is not in the store.
     """
     session = get_session(session_id)
@@ -198,6 +202,7 @@ def replay_session(
         session_id,
         client=client,
         persist=False,
+        force_distill=bool(stored),
     )
 
     replayed = list(result.persisted)

--- a/src/bsela/llm/distiller.py
+++ b/src/bsela/llm/distiller.py
@@ -198,10 +198,15 @@ def distill_session(
     *,
     client: LLMClient,
     persist: bool = True,
+    force_distill: bool = False,
     judge_threshold: float = 0.8,
     recent_lessons_limit: int = 10,
 ) -> DistillationResult:
-    """Run judge→distill for one session. Returns the decision trail."""
+    """Run judge→distill for one session. Returns the decision trail.
+
+    When ``force_distill`` is true, the judge still runs for telemetry but a
+    "healthy" verdict does not short-circuit the distiller call.
+    """
     session = get_session(session_id)
     if session is None:
         raise LookupError(f"session not found: {session_id}")
@@ -218,7 +223,7 @@ def distill_session(
         and not verdict.looped
         and not verdict.wasted_tokens
     )
-    if healthy:
+    if healthy and not force_distill:
         return DistillationResult(
             session_id=session_id,
             verdict=verdict,

--- a/src/bsela/memory/store.py
+++ b/src/bsela/memory/store.py
@@ -27,6 +27,8 @@ from bsela.memory.models import (
     SessionRecord,
 )
 
+_ENGINES: set[Engine] = set()
+
 
 def bsela_home() -> Path:
     """Resolve the BSELA home directory (``BSELA_HOME`` env or ``~/.bsela``)."""
@@ -57,6 +59,7 @@ def _engine_for(url: str) -> Engine:
         cursor.close()
 
     SQLModel.metadata.create_all(engine)
+    _ENGINES.add(engine)
     return engine
 
 
@@ -66,8 +69,9 @@ def get_engine() -> Engine:
 
 def reset_engine_cache() -> None:
     """Dispose every cached engine. Intended for tests."""
-    for engine in list(_engine_for.__wrapped__.__dict__.values()):
+    for engine in _ENGINES:
         engine.dispose()
+    _ENGINES.clear()
     _engine_for.cache_clear()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,10 +22,10 @@ def tmp_bsela_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[
     (home / "logs").mkdir()
     (home / "reports").mkdir()
     monkeypatch.setenv("BSELA_HOME", str(home))
-    memory_store._engine_for.cache_clear()
+    memory_store.reset_engine_cache()
     config_module.clear_cache()
     yield home
-    memory_store._engine_for.cache_clear()
+    memory_store.reset_engine_cache()
     config_module.clear_cache()
 
 

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -258,18 +258,21 @@ def test_replay_drift_no_records(tmp_bsela_home: Path) -> None:
 
 
 def test_replay_drift_below_threshold_no_alert(tmp_bsela_home: Path) -> None:
-    sess = save_session(
-        SessionRecord(
-            source="claude_code",
-            transcript_path="/tmp/fake.jsonl",
-            content_hash="h1",
-            ingested_at=NOW - timedelta(hours=2),
+    sessions = [
+        save_session(
+            SessionRecord(
+                source="claude_code",
+                transcript_path=f"/tmp/fake-{idx}.jsonl",
+                content_hash=f"h{idx}",
+                ingested_at=NOW - timedelta(hours=2),
+            )
         )
-    )
-    _replay_rec(sess.id, had_drift=False)
-    _replay_rec(sess.id, had_drift=False)
-    _replay_rec(sess.id, had_drift=True)
-    _replay_rec(sess.id, had_drift=True)  # 2/4 = 50% < replay_drift_threshold, not over
+        for idx in range(4)
+    ]
+    _replay_rec(sessions[0].id, had_drift=False)
+    _replay_rec(sessions[1].id, had_drift=False)
+    _replay_rec(sessions[2].id, had_drift=True)
+    _replay_rec(sessions[3].id, had_drift=True)  # 2/4 sessions drifted = 50%
 
     report = build_audit(window_days=30, now=NOW)
     assert report.replay_drift.sessions_replayed == 4
@@ -280,23 +283,42 @@ def test_replay_drift_below_threshold_no_alert(tmp_bsela_home: Path) -> None:
 
 
 def test_replay_drift_above_threshold_triggers_alert(tmp_bsela_home: Path) -> None:
-    sess = save_session(
-        SessionRecord(
-            source="claude_code",
-            transcript_path="/tmp/fake.jsonl",
-            content_hash="h2",
-            ingested_at=NOW - timedelta(hours=2),
+    sessions = [
+        save_session(
+            SessionRecord(
+                source="claude_code",
+                transcript_path=f"/tmp/fake-drift-{idx}.jsonl",
+                content_hash=f"hd{idx}",
+                ingested_at=NOW - timedelta(hours=2),
+            )
         )
-    )
-    _replay_rec(sess.id, had_drift=True)
-    _replay_rec(sess.id, had_drift=True)
-    _replay_rec(sess.id, had_drift=True)
-    _replay_rec(sess.id, had_drift=True)  # 4/4 = 100% > any threshold
+        for idx in range(4)
+    ]
+    for sess in sessions:
+        _replay_rec(sess.id, had_drift=True)  # 4/4 = 100% > any threshold
 
     report = build_audit(window_days=30, now=NOW)
     assert report.replay_drift.drift_rate == pytest.approx(1.0)
     assert report.replay_drift.over_threshold
     assert any("REPLAY DRIFT" in a for a in report.alerts)
+
+
+def test_replay_drift_uses_latest_record_per_session(tmp_bsela_home: Path) -> None:
+    sess = save_session(
+        SessionRecord(
+            source="claude_code",
+            transcript_path="/tmp/fake-latest.jsonl",
+            content_hash="h-latest",
+            ingested_at=NOW - timedelta(hours=2),
+        )
+    )
+    _replay_rec(sess.id, had_drift=True, replayed_at=NOW - timedelta(hours=3))
+    _replay_rec(sess.id, had_drift=False, replayed_at=NOW - timedelta(hours=1))
+
+    report = build_audit(window_days=30, now=NOW)
+    assert report.replay_drift.sessions_replayed == 1
+    assert report.replay_drift.sessions_with_drift == 0
+    assert report.replay_drift.drift_rate == 0.0
 
 
 def test_replay_drift_outside_window_excluded(tmp_bsela_home: Path) -> None:
@@ -323,16 +345,24 @@ def test_render_markdown_includes_replay_drift_section(tmp_bsela_home: Path) -> 
 
 
 def test_render_markdown_shows_replay_counts(tmp_bsela_home: Path) -> None:
-    sess = save_session(
+    sess_a = save_session(
         SessionRecord(
             source="claude_code",
-            transcript_path="/tmp/fake.jsonl",
-            content_hash="h4",
+            transcript_path="/tmp/fake-a.jsonl",
+            content_hash="h4a",
             ingested_at=NOW - timedelta(hours=2),
         )
     )
-    _replay_rec(sess.id, had_drift=False)
-    _replay_rec(sess.id, had_drift=True)
+    sess_b = save_session(
+        SessionRecord(
+            source="claude_code",
+            transcript_path="/tmp/fake-b.jsonl",
+            content_hash="h4b",
+            ingested_at=NOW - timedelta(hours=2),
+        )
+    )
+    _replay_rec(sess_a.id, had_drift=False)
+    _replay_rec(sess_b.id, had_drift=True)
 
     report = build_audit(window_days=30, now=NOW)
     md = render_markdown(report)

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -115,6 +115,32 @@ def test_replay_healthy_session_produces_no_diff(
     assert "healthy" in result.summary()
 
 
+def test_replay_with_stored_lessons_forces_distill_even_if_judge_is_healthy(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions(status="captured")[0].id
+    err = _seed_error(session_id)
+    rule = "Do not retry on the same error twice"
+    save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule=rule,
+            why="loop detected",
+            how_to_apply="switch strategy",
+            confidence=0.88,
+            status="pending",
+        )
+    )
+
+    client = _fake_client(verdict=_healthy_verdict(), distill=_distill_response(rule))
+    result = replay_session(session_id, client=client)
+
+    assert result.distilled
+    assert any(d.kind == "unchanged" for d in result.diff), result.diff
+
+
 def test_replay_no_stored_lessons_shows_all_added(
     tmp_bsela_home: Path, sample_clean_session: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- dispose cached SQLAlchemy engines during test fixture lifecycle to stop sqlite ResourceWarning leaks
- make replay comparisons less noisy by forcing distillation when stored lessons exist
- compute replay drift alarm from latest replay per session (not every historical run)

## Why
- tests were green but emitted widespread unclosed sqlite connection warnings
- replay drift alert was inflated by judge-gating variance and repeated historical runs for the same session

## Changes
- memory store tracks created engines and disposes them in reset_engine_cache()
- pytest fixture now calls reset_engine_cache() before/after each isolated BSELA home
- distill_session(..., force_distill=True) support added and used by replay when a session has stored lessons
- auditor now aggregates replay drift by latest record per session in window
- replay/auditor regression tests updated for new semantics

## Test plan
- [x] Local checks pass
- [x] Behavior verified

## Risks
- replay drift numbers may change suddenly after deploy because denominator semantics changed to latest-per-session
- force-distill on replay increases LLM calls for sessions that judge healthy (replay-only path)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes replay drift semantics (latest-per-session) and forces distillation during replay when stored lessons exist, which can alter alert rates and increase LLM calls. Also adjusts SQLAlchemy engine caching/disposal behavior, which could affect connection lifecycle in tests and long-running processes if misused.
> 
> **Overview**
> **Replay drift is now less noisy and more representative.** `build_audit` computes replay drift using only the *latest* `ReplayRecord` per session in the window (instead of counting every historical replay), and tests were updated to match the new denominator/alert behavior.
> 
> **Replay now distills for sessions that already have lessons even if the judge says “healthy”.** `distill_session` adds a `force_distill` option and `replay_session` enables it when stored lessons exist, shifting drift detection toward lesson stability rather than judge variance.
> 
> **SQLite engine cache cleanup is hardened for tests.** The store tracks created SQLAlchemy engines and `reset_engine_cache()` now disposes them (fixture uses this before/after each isolated `BSELA_HOME`) to eliminate unclosed-connection warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ffddcaac05cc4da4a5a89fdbe0d1c9d0d7d3e9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->