### PR TITLE
docs(agents): add Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,27 @@ Rules distilled from real session errors. Confidence ≥ 0.85 auto-approved; oth
 - **External CLI tools on PATH** (conf=0.85): Before running any external binary (`pnpm`, `uv`, `make`, `node`), verify it exists with `command -v <tool>` or equivalent. Fail fast with a clear message rather than letting a missing binary produce an opaque error mid-pipeline.
 - **No hard-coded dates in tests** (conf=0.70): Never embed absolute timestamps or date literals in test assertions. Use relative offsets from `datetime.now()` or freeze the clock with a time-mocking utility so tests remain valid as time advances.
 - **Import sanity before test suite** (conf=0.75): Before running the full pytest suite, perform a lightweight import check (`python -c "import <pkg>"`) for each top-level module. A `ModuleNotFoundError` at collection time wastes a full CI run; surface it at the pre-test stage instead.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | What it does | How to run |
+|---------|-------------|------------|
+| Python CLI (`bsela`) | Core control plane — capture, detect, distill, audit | `uv run bsela <cmd>` or just `bsela <cmd>` after `uv tool install -e .` |
+| MCP server (`mcp/`) | Read-only MCP tools for editors | `cd mcp && node dist/server.js` (build first with `pnpm build`) |
+
+### Key commands
+
+- **Full Python gate:** `make check` (ruff lint + format-check + mypy + pytest 99% coverage)
+- **Quick test only:** `uv run pytest -q`
+- **MCP gate:** `make mcp-check` (prettier + eslint + tsc + vitest)
+- **Health check:** `uv run bsela doctor`
+
+### Gotchas
+
+- **MCP tests need `bsela` on PATH.** The MCP server shells out to the `bsela` CLI binary. Run `uv tool install --force -e .` before `pnpm check` in `mcp/`, or all CLI-dependent tests (`bsela-client.test.ts`, `parity.test.ts`) will fail with `spawn bsela ENOENT`.
+- **No external services needed.** SQLite is embedded (WAL mode, stored at `~/.bsela/bsela.db`). No Postgres, Redis, or Docker.
+- **LLM API keys are optional.** Only `distill`, `process`, and `replay` commands require `ANTHROPIC_API_KEY` or `OPENROUTER_API_KEY`. All other commands (status, ingest, detect, route, audit, doctor) work without them.
+- **Python 3.13 required.** The `pyproject.toml` specifies `requires-python = ">=3.13"`. Use `uv python install 3.13` if the system Python is older.
+- **pnpm esbuild warning is harmless.** The `Ignored build scripts: esbuild` warning during `pnpm install` is non-blocking — the MCP build uses `tsc`, not esbuild.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Adds `## Cursor Cloud specific instructions` section to `AGENTS.md` with services overview, key commands, and non-obvious gotchas for future cloud agents.

## Why
- Future Cursor Cloud agents need to know that MCP tests require `bsela` on PATH (`uv tool install -e .` before `pnpm check`), that no external services are needed, and which commands to run for the Python and MCP gates.

## Changes
- `AGENTS.md`: Added cloud-specific section documenting services table, key dev commands, and 5 environment gotchas discovered during setup.

## Test plan
- [x] Local checks pass (`make check` — ruff, mypy, pytest 417 pass @ 99.65% coverage)
- [x] MCP checks pass (`pnpm check` in `mcp/` — 59 tests pass)
- [x] Behavior verified (ingested demo transcript, ran status/errors/route/audit/doctor)

## Risks
- None — documentation-only change.

### Environment verification

Demo of all services working:

[bsela_demo_output.log](https://cursor.com/agents/bc-b03e6f28-0722-4414-8c66-230c0f4d448d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbsela_demo_output.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b03e6f28-0722-4414-8c66-230c0f4d448d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b03e6f28-0722-4414-8c66-230c0f4d448d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

