### PR TITLE
docs: replay drift handoff after PR #40 validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,30 @@ For **Cursor** (MCP wiring), see [`adapters/cursor/README.md`](adapters/cursor/R
 
 For Codex CLI continuation from this repo, see [`CODEX.md`](CODEX.md).
 
-## Last session — 2026-05-10 (semantic replay-diff metric)
+## Last session — 2026-05-10 (PR #40 landed; replay drift still 100%)
+
+### Completed
+
+1. **PR #40 merged** — squash merge on `main`: `9b2217e` (*fix(core): isolate replay from mutable lesson context*). Isolates replay distillation from mutable lesson context (`recent_lessons=[]`, `replay_harness` in JSON, prompt copy in `docs/prompts/failure-distiller.md`). Merged while CI was green (Bugbot pattern unchanged).
+2. **Replay batch** — listed 15 drift-flagged sessions (`bsela replays list --drift-only --json`), ran `bsela replay` for each (short UUID prefixes where needed). One session needed a retry after HTTP read timeout.
+3. **Audit re-check** — `uv run bsela audit --weekly --json`: **`replay_drift` unchanged** — `sessions_replayed=15`, `sessions_with_drift=15`, `drift_rate=1.0`, `threshold=0.88`, alert **REPLAY DRIFT** still present.
+4. **Root cause (no code fix shipped)** — inspected replay CLI diffs (e.g. `d66099c6`, `7d0e9afa`, `3fc74662`): drift is dominated by **different lesson multisets** (new topics on replay), not sub-threshold paraphrases of the same rule. Lowering Jaccard pairing alone will not clear the alarm. Full write-up: [`docs/reports/replay-drift-2026-05-10.md`](docs/reports/replay-drift-2026-05-10.md).
+
+### Repo state at session end
+
+- **main (origin):** includes `9b2217e` from PR #40.
+- **Open PRs:** docs handoff from branch `docs/replay-drift-handoff-2026-05-10` (report + this file).
+- **Audit:** `REPLAY DRIFT` weekly alert **still firing** until policy/threshold or distiller stability work lands (see report “Recommended next steps”).
+
+### Next session — start here
+
+1. **Decide policy** — Either accept higher baseline drift on free-tier models (ADR + adjust `audit.replay_drift_threshold` or add a non-blocking mode), or invest in **structured distillation** / paid Haiku to shrink lesson churn.
+2. **Branch-protection** — still worth relaxing Bugbot from required SUCCESS to pass-or-neutral when friction recurs.
+3. **Optional:** max-weight bipartite pairing + replay-only pairing threshold — small win for paraphrase-only cases; will not address multiset churn evidenced in the report.
+
+---
+
+## Previous session — 2026-05-10 (semantic replay-diff metric)
 
 ### Completed
 

--- a/docs/reports/replay-drift-2026-05-10.md
+++ b/docs/reports/replay-drift-2026-05-10.md
@@ -1,0 +1,58 @@
+# Replay drift investigation — 2026-05-10
+
+## Summary
+
+After **PR #40** merged (`replay_harness` JSON flag + empty `recent_lessons` in replay mode + prompt guidance), all **15** sessions in the weekly audit window were re-run with `bsela replay`. **`replay_drift.drift_rate` stayed at 1.0** (15/15 with `had_drift=True`, threshold 0.88). The weekly **REPLAY DRIFT** alert therefore remains active.
+
+This is **not** primarily a Jaccard pairing threshold issue: several high-drift replays show **different substantive rules** on replay versus what was originally stored for the same session, not near-paraphrases sitting just below `dedupe.similarity_threshold` (0.78).
+
+## Evidence (CLI excerpts)
+
+### `d66099c6` (stored=3, replayed=3, +3 −3 ~0)
+
+Stored lessons (themes): avoid duplicate tool calls; clear message when an external binary is missing; import sanity before full test suite.
+
+Replayed lessons (themes): validate `pyproject.toml` author email; ensure CI runtime tools exist; run ruff/mypy before tests.
+
+Token overlap between matched “slots” is low — these are **different extractions** from the same session, not wording variants of the same rule.
+
+### `7d0e9afa` (stored=3, replayed=2, +2 −3 ~0)
+
+Count mismatch plus topic shift — pairing cannot collapse this to “unchanged” without losing fidelity.
+
+### `3fc74662` (stored=1, replayed=2, +2 −1 ~0)
+
+One stored rule on tool-argument coercion versus two replayed globals (numeric validation + stack traces) — again **lesson set churn**, not a single paraphrase split across the threshold.
+
+### Operational note
+
+One replay (`49120abe…`) hit **`TimeoutError`** during the OpenRouter/HTTP read path on the first attempt; a **retry succeeded**. Rate-limit guidance (sleep + retry) remains appropriate for batch replays.
+
+## Hypotheses
+
+| # | Hypothesis | Verdict |
+|---|------------|---------|
+| (a) | Paraphrases fall below Jaccard 0.78 so `+`/`-` inflate while semantics match | **Ruled out** as the dominant driver for inspected sessions; counterexamples show unrelated rule text. |
+| (b) | Stored lessons are outdated vs current distiller prompt | **Possible** in the weak sense that any prompt edit moves the extraction frontier; **not** evidence that approved rows are “wrong” — do **not** auto-rollback. |
+| (c) | Judge variance flips healthy ↔ unhealthy | **Secondary** for diff magnitude when `force_distill` runs with existing lessons; lesson **content** variance dominates the signal. |
+
+## Recommended next steps (pick one primary track)
+
+1. **Treat replay drift as a model-stability metric, not a release gate (until models stabilize).** Add an ADR and raise `audit.replay_drift_threshold` (or introduce a separate “strict” profile) so the weekly job stays informative without permanent red on free-tier models.
+
+2. **Structured distillation output** (e.g. fixed rubric slots / schema-first candidates) to reduce **which** rule the model chooses for a given transcript — engineering effort; pairs well with Haiku on paid tier.
+
+3. **Optional**: replay-only **lower pairing threshold** or **max-weight bipartite** pairing helps **pure paraphrase** cases; it will **not** clear alerts when replay emits a genuinely different lesson multiset (evidence above).
+
+## Commands used
+
+```bash
+uv run bsela audit --weekly --json
+uv run bsela replays list --drift-only --json --limit 100
+uv run bsela replay <session-prefix>
+```
+
+## References
+
+- PR #40 — <https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/pull/40> — merge commit `9b2217efa663c66621e883df724b4a6e38c52766`.
+- ADR [0007 — P7 replay and drift](../decisions/0007-p7-replay-and-drift.md).


### PR DESCRIPTION
## Summary

Documents the outcome of replaying all 15 drift-flagged sessions after PR #40 merged. Weekly `replay_drift` stayed at **100%**; the investigation concludes lesson **multiset churn** from the distiller dominates, not Jaccard pairing gaps alone.

## Changes

- `docs/reports/replay-drift-2026-05-10.md` — evidence, ruled hypotheses, recommended next steps.
- `CLAUDE.md` — last-session handoff for the next operator.

## Merge

CI should be green; if Bugbot is the only blocker with NEUTRAL, squash-merge with admin matches repo precedent.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates capturing investigation results and operator handoff; no production code or configuration changes.
> 
> **Overview**
> Documents the post-PR #40 replay validation showing the weekly `replay_drift` alert remains at **100%** and that drift is driven by **lesson set churn** rather than near-paraphrase pairing.
> 
> Adds a new report (`docs/reports/replay-drift-2026-05-10.md`) with evidence, ruled-out hypotheses, and recommended next steps (policy/threshold changes vs structured distillation), and updates `CLAUDE.md` with a “last session” handoff plus concrete next-session actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ae498d5bab8afba856e2ad494f7b609f67b0cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->