### PR TITLE
fix(pyproject): correct project URLs to canonical public repo (closes #45)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,9 +41,9 @@ dev = [
 bsela = "bsela.cli:app"
 
 [project.urls]
-Homepage = "https://github.com/subkoks/bsela"
-Repository = "https://github.com/subkoks/bsela"
-Issues = "https://github.com/subkoks/bsela/issues"
+Homepage = "https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI"
+Repository = "https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI"
+Issues = "https://github.com/subkoks/BEST-Self-Enhancement-Learning-AI/issues"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
Fixes Homepage / Repository / Issues URLs in pyproject.toml from the old `subkoks/bsela` staging name to the canonical public repo `subkoks/BEST-Self-Enhancement-Learning-AI`.

Closes #45

Made with [Cursor](https://cursor.com)