### PR TITLE
Restrict GitHub Actions workflows to read-only contents access

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,6 +6,9 @@ on:
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -18,6 +18,9 @@ on:
       - "pyproject.toml"
       - "uv.lock"
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit `contents: read` permissions to the CI, MCP, and weekly audit workflows.
- Keep the workflows functional while tightening default GitHub Actions access.
- Addresses the CodeQL `actions/missing-workflow-permissions` alerts on the affected workflow files.

## Testing
- Local validation passed for the updated workflow YAML.
- Repo gates remained green locally, including lint, typecheck, test, and MCP checks.