### PR TITLE
fix(core): reclassify replay drift as informational, not a blocking alert (#58)

### DIFF
--- a/docs/decisions/0007-p7-replay-and-drift.md
+++ b/docs/decisions/0007-p7-replay-and-drift.md
@@ -22,7 +22,7 @@ P7 per the roadmap:
 
 2. **Diff is normalized and rule-centric.** Comparison normalises whitespace + case, compares `(rule, scope, confidence)` tuples. Four diff kinds: `unchanged`, `added`, `removed`, `changed`. `changed` fires when the rule text matches but scope or confidence shifted beyond the precision of the stored float.
 
-3. **Drift alarm is threshold-based and auditor-integrated.** `bsela audit` counts `had_drift=True` replay records in the window. If the ratio exceeds `thresholds.toml → auditor.replay_drift_threshold` (default 0.25), the audit exits non-zero and prints a `REPLAY DRIFT` alert. The weekly launchd job therefore surfaces regressions automatically.
+3. **Drift alarm is threshold-based and auditor-integrated.** `bsela audit` counts `had_drift=True` replay records in the window. If the ratio exceeds `thresholds.toml → auditor.replay_drift_threshold` (default 0.25), the audit exits non-zero and prints a `REPLAY DRIFT` alert. The weekly launchd job therefore surfaces regressions automatically. **(Superseded by [ADR 0010](0010-replay-drift-informational.md): on nondeterministic / free-tier models replay drift is an _informational warning_, not a blocking alert, and no longer gates the `bsela audit` exit code.)**
 
 4. **`bsela rollback <lesson-id>` reverts a lesson to `rolled_back` status.** Rollback does not delete — it soft-marks so downstream aggregates (report, audit) exclude the lesson from the active corpus. Every change remains a commit; the `rolled_back` status is the undo token. Re-instating a rolled-back lesson is a manual `bsela review propose` → auto-merge cycle.
 

--- a/docs/decisions/0010-replay-drift-informational.md
+++ b/docs/decisions/0010-replay-drift-informational.md
@@ -1,0 +1,85 @@
+# ADR 0010 — Replay drift is an informational metric, not a release gate
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Supersedes:** ADR [0007](0007-p7-replay-and-drift.md) §3 (the "drift alarm gates the run" framing).
+
+## Context
+
+ADR 0007 shipped the replay harness and a drift alarm: `bsela audit` counted
+`had_drift=True` replay records over the window and, if the rate exceeded
+`config/thresholds.toml → audit.replay_drift_threshold`, appended a
+`REPLAY DRIFT` entry to the blocking `alerts` list — which makes the `bsela
+audit` command exit non-zero (`cli.py`, `raise typer.Exit(code=1 if alerts)`).
+
+That alarm has fired continuously since 2026-05. Multiple sessions drove it to
+ground:
+
+- Determinism was hardened end-to-end — `temperature=0` (Anthropic + OpenRouter),
+  `seed` (OpenRouter), Jaccard semantic pairing in `_diff_lessons`, and replay
+  input isolation (`recent_lessons=[]`, `replay_harness=True`). Merged via #34,
+  #36, #40.
+- Despite that, the rate stayed at ~100%. The investigation
+  ([docs/reports/replay-drift-2026-05-10.md](../reports/replay-drift-2026-05-10.md))
+  established the cause is **not** sub-threshold paraphrasing: on replay the
+  distiller emits a genuinely **different lesson multiset** (different rules, not
+  reworded ones) for the same transcript. This is model-selection variance —
+  intrinsic to nondeterministic / free-tier models that ignore `seed` and vary
+  judge verdicts — not a regression in stored lessons.
+
+ADR 0007's own re-open condition anticipated this: "Drift rate … above 25% for
+more than two consecutive audit windows — investigate prompt or model
+instability **rather than tuning the threshold**." The investigation is done; the
+conclusion is model instability. Lowering the bar to silence the alarm would be
+dishonest masking, and raising the threshold is explicitly discouraged.
+
+## Decision
+
+1. **Replay drift is reclassified from a blocking *alert* to an informational
+   *warning*.** `AuditReport` now carries two severities: `alerts` (blocking:
+   cost over budget, stale lessons, ADR hygiene) and `warnings` (informational:
+   replay drift). `build_audit` appends the replay-drift line to `warnings`.
+
+2. **The CLI exit code gates on `alerts` only.** `bsela audit` exits non-zero
+   only for blocking alerts; informational warnings never fail the run. The
+   drift rate, threshold, and `over_threshold` flag remain fully visible in both
+   the markdown report (`## Warnings` + `## Replay Drift`) and the
+   `bsela audit --json` payload (new `warnings` array; `replay_drift` block
+   unchanged).
+
+3. **The threshold is retained as a sensitivity knob, not a gate.** It still
+   decides whether the informational warning is emitted, so the signal stays
+   useful for tracking model stability over time and tightens automatically
+   toward 0.25 when the pipeline moves to deterministic Haiku (per the existing
+   comment in `thresholds.toml`).
+
+## Consequences
+
+- The weekly audit stops permanently red on free-tier models while still
+  reporting the drift rate. Operators reading the digest see replay drift under
+  `## Warnings`, clearly marked informational.
+- No change to the replay harness, the diff algorithm, or stored lessons. This
+  is purely a severity reclassification of an existing signal.
+- If the pipeline later moves to a deterministic paid model and drift stays
+  high, that is a genuine regression — but it would then be investigated via the
+  warning trend, and promotion back to a blocking alert is a one-line change
+  (move the `warnings.append` back to `alerts.append`) gated by a new ADR.
+
+## Rejected alternatives
+
+- **Raise `replay_drift_threshold` toward 1.0.** Rejected: hides the signal and
+  contradicts ADR 0007's re-open guidance against threshold tuning.
+- **Structured / schema-first distillation to stabilise lesson selection.**
+  Deferred, not rejected: it is the right long-term fix (report Option 2) but is
+  real engineering effort and pairs with a paid deterministic model. It does not
+  block this reclassification.
+- **Drop the metric entirely.** Rejected: drift rate is a legitimate
+  model-stability signal; it just is not a release gate on nondeterministic
+  models.
+
+## References
+
+- ADR [0007 — P7 replay and drift](0007-p7-replay-and-drift.md) — original gate.
+- [docs/reports/replay-drift-2026-05-10.md](../reports/replay-drift-2026-05-10.md) — root-cause investigation (Option 1).
+- [config/thresholds.toml](../../config/thresholds.toml) — `audit.replay_drift_threshold`.
+- Issue #58 — replay harness determinism / audit drift.

--- a/mcp/src/bsela-client.ts
+++ b/mcp/src/bsela-client.ts
@@ -85,6 +85,7 @@ export interface AuditPayload {
     scanned: boolean;
   };
   alerts: Array<string>;
+  warnings: Array<string>;
 }
 
 export interface LessonItem {
@@ -261,6 +262,8 @@ function isAuditPayload(value: unknown): value is AuditPayload {
     typeof v.errors_total === "number" &&
     Array.isArray(v.alerts) &&
     v.alerts.every((item) => typeof item === "string") &&
+    Array.isArray(v.warnings) &&
+    v.warnings.every((item) => typeof item === "string") &&
     typeof sessions === "object" &&
     sessions !== null &&
     typeof (sessions as Record<string, unknown>).total === "number" &&

--- a/mcp/tests/bsela-client.test.ts
+++ b/mcp/tests/bsela-client.test.ts
@@ -130,6 +130,7 @@ describe("BselaClient.audit", () => {
       "generated_at",
       "replay_drift",
       "sessions",
+      "warnings",
       "window_days",
       "window_end",
       "window_start",

--- a/src/bsela/cli.py
+++ b/src/bsela/cli.py
@@ -1070,6 +1070,7 @@ def _audit_json_payload(report_data: object) -> dict[str, object]:
             "scanned": report_data.adrs.scanned,
         },
         "alerts": list(report_data.alerts),
+        "warnings": list(report_data.warnings),
     }
 
 
@@ -1120,8 +1121,12 @@ def audit(
         typer.echo(render_audit_markdown(report_data))
     else:
         target = write_audit_report(report_data, output)
-        typer.echo(f"audit: wrote window={window}d, alerts={len(report_data.alerts)} to {target}")
-    # Non-zero exit on active alerts so the weekly launchd run surfaces in logs.
+        typer.echo(
+            f"audit: wrote window={window}d, alerts={len(report_data.alerts)} "
+            f"warnings={len(report_data.warnings)} to {target}"
+        )
+    # Non-zero exit on blocking alerts only; informational warnings (e.g. replay
+    # drift on nondeterministic models, ADR 0010) do not fail the run.
     raise typer.Exit(code=1 if report_data.alerts else 0)
 
 

--- a/src/bsela/core/auditor.py
+++ b/src/bsela/core/auditor.py
@@ -15,9 +15,16 @@ Alerts are derived from ``config/thresholds.toml``:
 * ``cost.monthly_budget_usd``         — trip if prorated burn > budget.
 * ``audit.drift_alarm_threshold``     — trip if stale-lesson fraction
   exceeds threshold.
-* ``audit.replay_drift_threshold``    — trip if fraction of replayed
-  sessions that showed drift exceeds threshold (P7 replay drift alarm).
+* ``audit.replay_drift_threshold``    — replayed-session drift rate. Emitted
+  as an *informational warning*, not a blocking alert: on nondeterministic /
+  free-tier models the distiller selects a different lesson multiset per run,
+  so replay drift tracks model stability rather than a regression gate
+  (ADR 0010, supersedes the gate framing in ADR 0007 §3).
 * ADR status header — surface any ADR file missing ``**Status:**``.
+
+Two severities: ``alerts`` are blocking signals (cost, lesson staleness, ADR
+hygiene); ``warnings`` are informational (replay drift). Both render and are
+exposed in the ``bsela audit --json`` payload.
 """
 
 from __future__ import annotations
@@ -122,6 +129,7 @@ class AuditReport:
     replay_drift: ReplayDriftSnapshot
     adrs: AdrSnapshot
     alerts: tuple[str, ...] = field(default_factory=tuple)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
 
     @property
     def quarantine_rate(self) -> float:
@@ -255,6 +263,7 @@ def build_audit(
     adrs = _scan_adrs()
 
     alerts: list[str] = []
+    warnings: list[str] = []
     if cost_snapshot.over_budget:
         alerts.append(
             f"COST: prorated monthly spend ${cost_snapshot.prorated_monthly_usd:.2f} "
@@ -269,12 +278,16 @@ def build_audit(
             f"{drift_snapshot.threshold:.1%} threshold)"
         )
     if replay_drift_snapshot.over_threshold:
-        alerts.append(
-            f"REPLAY DRIFT: {replay_drift_snapshot.sessions_with_drift}/"
-            f"{replay_drift_snapshot.sessions_replayed} replayed sessions showed drift "
+        # Informational, not blocking: on nondeterministic / free-tier models the
+        # distiller picks a different lesson multiset per run, so a high replay
+        # drift rate reflects model-selection variance rather than a regression.
+        # See ADR 0010 (supersedes the gate framing in ADR 0007 §3).
+        warnings.append(
+            f"REPLAY DRIFT (informational): {replay_drift_snapshot.sessions_with_drift}/"
+            f"{replay_drift_snapshot.sessions_replayed} replayed sessions changed lessons "
             f"({replay_drift_snapshot.drift_rate:.1%} > "
             f"{replay_drift_snapshot.threshold:.1%} threshold) — "
-            f"distillation output is diverging from stored lessons"
+            f"model-selection variance, not a release gate (ADR 0010)"
         )
     if adrs.missing_status:
         alerts.append(
@@ -295,11 +308,30 @@ def build_audit(
         replay_drift=replay_drift_snapshot,
         adrs=adrs,
         alerts=tuple(alerts),
+        warnings=tuple(warnings),
     )
 
 
 def _fmt_iso(ts: datetime) -> str:
     return ts.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _render_list_section(
+    lines: list[str],
+    title: str,
+    items: tuple[str, ...],
+    *,
+    empty: str,
+    marker: str,
+) -> None:
+    """Append a ``## title`` section: bulleted ``items`` or an ``empty`` note."""
+    lines.append(f"## {title}")
+    lines.append("")
+    if items:
+        lines.extend(f"- {marker}{item}" for item in items)
+    else:
+        lines.append(empty)
+    lines.append("")
 
 
 def render_markdown(report: AuditReport) -> str:
@@ -314,14 +346,8 @@ def render_markdown(report: AuditReport) -> str:
     )
     lines.append("")
 
-    lines.append("## Alerts")
-    lines.append("")
-    if not report.alerts:
-        lines.append("_all clear._")
-    else:
-        for alert in report.alerts:
-            lines.append(f"- ⚠️ {alert}")
-    lines.append("")
+    _render_list_section(lines, "Alerts", report.alerts, empty="_all clear._", marker="⚠️ ")
+    _render_list_section(lines, "Warnings", report.warnings, empty="_none._", marker="")
 
     lines.append("## Capture")
     lines.append("")

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -282,7 +282,9 @@ def test_replay_drift_below_threshold_no_alert(tmp_bsela_home: Path) -> None:
     assert not any("REPLAY DRIFT" in a for a in report.alerts)
 
 
-def test_replay_drift_above_threshold_triggers_alert(tmp_bsela_home: Path) -> None:
+def test_replay_drift_above_threshold_warns_not_alerts(tmp_bsela_home: Path) -> None:
+    # Replay drift is informational (ADR 0010): it surfaces as a warning and must
+    # NOT enter the blocking ``alerts`` list (which gates the CLI exit code).
     sessions = [
         save_session(
             SessionRecord(
@@ -300,7 +302,31 @@ def test_replay_drift_above_threshold_triggers_alert(tmp_bsela_home: Path) -> No
     report = build_audit(window_days=30, now=NOW)
     assert report.replay_drift.drift_rate == pytest.approx(1.0)
     assert report.replay_drift.over_threshold
-    assert any("REPLAY DRIFT" in a for a in report.alerts)
+    assert any("REPLAY DRIFT" in w for w in report.warnings)
+    assert not any("REPLAY DRIFT" in a for a in report.alerts)
+
+
+def test_render_markdown_replay_drift_warning_section(tmp_bsela_home: Path) -> None:
+    # The non-empty ``## Warnings`` render branch + informational marker.
+    sessions = [
+        save_session(
+            SessionRecord(
+                source="claude_code",
+                transcript_path=f"/tmp/fake-warn-{idx}.jsonl",
+                content_hash=f"hw{idx}",
+                ingested_at=NOW - timedelta(hours=2),
+            )
+        )
+        for idx in range(4)
+    ]
+    for sess in sessions:
+        _replay_rec(sess.id, had_drift=True)
+
+    report = build_audit(window_days=30, now=NOW)
+    md = render_markdown(report)
+    assert "## Warnings" in md
+    assert "(informational)" in md
+    assert "REPLAY DRIFT" in md
 
 
 def test_replay_drift_uses_latest_record_per_session(tmp_bsela_home: Path) -> None:

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -200,6 +200,7 @@ _AUDIT_JSON_TOP_LEVEL = frozenset(
         "replay_drift",
         "adrs",
         "alerts",
+        "warnings",
     }
 )
 

--- a/tests/test_cli_route_audit.py
+++ b/tests/test_cli_route_audit.py
@@ -114,6 +114,7 @@ def test_audit_json_returns_machine_payload(tmp_bsela_home: Path) -> None:
         "generated_at",
         "replay_drift",
         "sessions",
+        "warnings",
         "window_days",
         "window_end",
         "window_start",


### PR DESCRIPTION
## Summary

Resolves the long-standing `REPLAY DRIFT` audit alarm (firing at ~100% since 2026-05) that kept `bsela audit` perpetually exiting non-zero.

The determinism work is already exhausted (#34/#36/#40: `temperature=0`, `seed`, Jaccard pairing, replay input isolation). The root-cause investigation (`docs/reports/replay-drift-2026-05-10.md`) established the cause is **free-tier model nondeterminism** — the distiller selects a different lesson *multiset* per run, not sub-threshold paraphrases. ADR 0007's own re-open condition says to "investigate model instability rather than tuning the threshold."

So this **reclassifies replay drift from a blocking `alert` to an informational `warning`** rather than masking it by raising the threshold.

## Changes
- **auditor**: `AuditReport.warnings` field; `REPLAY DRIFT` → `warnings`; `_render_list_section` helper; new `## Warnings` markdown section. Drift rate / threshold / `over_threshold` stay fully visible in markdown + JSON.
- **cli**: `audit --json` payload gains `warnings`; summary shows warnings count; **exit code still gates on blocking `alerts` only** — `bsela audit` now exits 0 when only replay drift is present.
- **mcp**: `AuditPayload` interface + `isAuditPayload` guard + client contract test carry the new `warnings` key (CLI/MCP parity preserved).
- **ADR 0010** (Accepted) documents the decision; supersedes ADR 0007 §3 (annotated with a pointer).

## Verification
- `make check`: 426 passed, coverage 99.79% (ruff + mypy + format clean).
- `make mcp-check`: prettier + eslint + tsc + vitest (59) green.
- Real store: `bsela audit --weekly` now reports `alerts: []`, drift under `warnings`, **exit 0** (was 1).

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)