### PR TITLE
test(core): pin audit exit 0 on replay-drift-only at CLI seam

### DIFF
--- a/tests/test_cli_route_audit.py
+++ b/tests/test_cli_route_audit.py
@@ -9,8 +9,8 @@ from pathlib import Path
 from typer.testing import CliRunner
 
 from bsela.cli import app
-from bsela.memory.models import Metric
-from bsela.memory.store import save_metric
+from bsela.memory.models import Metric, ReplayRecord, SessionRecord
+from bsela.memory.store import save_metric, save_replay_record, save_session
 
 
 def test_route_prints_class_model_and_reason() -> None:
@@ -163,3 +163,34 @@ def test_audit_json_preserves_nonzero_exit_when_alerts_present(tmp_bsela_home: P
     payload = json.loads(result.stdout)
     assert payload["cost"]["over_budget"] is True
     assert len(payload["alerts"]) >= 1
+
+
+def test_audit_exits_zero_on_replay_drift_only(tmp_bsela_home: Path) -> None:
+    """Regression for #58/#60 (ADR 0010): replay drift is informational.
+
+    The weekly launchd run regressed by exiting non-zero on ~100% replay drift,
+    an intrinsic property of free-tier nondeterministic models. With replay drift
+    over threshold and no blocking alert, ``bsela audit`` must exit 0 while still
+    surfacing REPLAY DRIFT as a warning (not an alert). Pinned at the CLI seam —
+    the exit code is the behaviour that actually regressed in production.
+    """
+    recent = datetime.now(UTC) - timedelta(hours=2)
+    for idx in range(4):
+        sess = save_session(
+            SessionRecord(
+                source="claude_code",
+                transcript_path=f"/tmp/replay-drift-{idx}.jsonl",
+                content_hash=f"rd{idx}",
+                ingested_at=recent,
+            )
+        )
+        save_replay_record(ReplayRecord(session_id=sess.id, had_drift=True, replayed_at=recent))
+
+    result = CliRunner().invoke(app, ["audit", "--json"])
+    assert result.exit_code == 0, result.stdout
+    payload = json.loads(result.stdout)
+    # Drift is real and surfaced...
+    assert payload["replay_drift"]["over_threshold"] is True
+    assert any("REPLAY DRIFT" in w for w in payload["warnings"])
+    # ...but routed to warnings, never to the blocking alerts that gate the exit code.
+    assert not any("REPLAY DRIFT" in a for a in payload["alerts"])


### PR DESCRIPTION
## Summary
- Add a CLI-level regression test locking `bsela audit` exit-code behaviour for replay drift (#58/#60, ADR 0010).

## Why
- The weekly launchd run regressed by exiting non-zero on ~100% replay drift — an intrinsic property of free-tier nondeterministic models, not a real regression.
- #60 fixed it (replay drift → informational warning, exit gates on blocking alerts only), but the exit-**0**-on-replay-drift-only direction was only pinned at the dataclass level (`warnings` vs `alerts`), not at the CLI seam where the exit code is actually decided.
- The exit-**1**-on-blocking-alert direction was already covered (cost-over-budget). A future refactor of the `audit()` exit logic could silently reintroduce the bug and pass every existing test.

## Changes
- `tests/test_cli_route_audit.py`: `test_audit_exits_zero_on_replay_drift_only` builds replay drift over threshold with no blocking alert, asserts `bsela audit --json` exits 0 while REPLAY DRIFT surfaces in `warnings` and never `alerts`.
- Extend imports (`ReplayRecord`, `SessionRecord`, `save_replay_record`, `save_session`).

## Test plan
- [x] Local checks pass — `pytest tests/test_cli_route_audit.py tests/test_auditor.py` (40 passed); ruff check + format clean.
- [x] Behavior verified — non-tautological: fails against pre-#60 code (exit 1 + missing `warnings` key), so it genuinely guards the regression.

## Risks
- None. Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)