### PR TITLE
fix(ci): authenticate Claude action via Pro/Max OAuth token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,8 +2,9 @@
 # Setup: https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md
 # Security: https://github.com/anthropics/claude-code-action/blob/main/docs/security.md
 #
-# ANTHROPIC_API_KEY (repository secret): GitHub web UI → this repo → Settings →
-# Secrets and variables → Actions → New repository secret. Name: ANTHROPIC_API_KEY.
+# Auth: CLAUDE_CODE_OAUTH_TOKEN (repository secret) — uses a Claude Pro/Max
+# subscription instead of pay-as-you-go API credit. Generate locally with
+# `claude setup-token`, then set it: `gh secret set CLAUDE_CODE_OAUTH_TOKEN`.
 # (Org-wide: Organization Settings → Secrets and variables → Actions.) Details:
 # adapters/claude/README.md section 7.
 
@@ -44,7 +45,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --max-turns 15
           plugin_marketplaces: |

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -85,18 +85,19 @@ Workflow: [`.github/workflows/claude.yml`](../../.github/workflows/claude.yml)
 1. Install the [Claude GitHub App](https://github.com/apps/claude) on this
    repository (or organization), per Anthropic’s
    [setup guide](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md).
-2. Add an Actions secret for the API key the workflow reads as
-   **`secrets.ANTHROPIC_API_KEY`**:
-   - **Repository secret:** open the GitHub repo in the browser → **Settings** (repo
-     settings, not your profile) → **Secrets and variables** → **Actions** →
-     **New repository secret** → Name **`ANTHROPIC_API_KEY`** → paste the key from
-     [Anthropic Console](https://console.anthropic.com/) → **Add secret**.
+2. Add an Actions secret for auth. The workflow reads
+   **`secrets.CLAUDE_CODE_OAUTH_TOKEN`** by default (Claude Pro/Max subscription —
+   no pay-as-you-go API credit needed):
+   - **OAuth (default):** run `claude setup-token` locally to mint a token, then
+     `gh secret set CLAUDE_CODE_OAUTH_TOKEN` (paste when prompted, or pipe via
+     stdin) — the token value never lands in the workflow file or git history.
+   - **Or (API key):** add **`ANTHROPIC_API_KEY`** (from
+     [Anthropic Console](https://console.anthropic.com/), pay-as-you-go credit) and
+     change the workflow step to pass
+     `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` instead of
+     `claude_code_oauth_token`.
    - **Organization secret (optional):** Organization **Settings** → **Secrets and
      variables** → **Actions** → new secret with the same name; grant this repo access.
-   - **Or (OAuth, Pro/Max):** add **`CLAUDE_CODE_OAUTH_TOKEN`** (from
-     `claude setup-token` locally) and change the workflow step to pass
-     `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` instead of
-     `anthropic_api_key`.
 3. Trigger by including **`@claude`** in an issue title/body, a PR review body,
    or a PR/issue comment (see the job `if:` filter in the workflow).
 


### PR DESCRIPTION
## Problem
The **Claude Code** workflow (`claude.yml`) fails on every `@claude` invocation with:

```
error: Claude Code returned an error result: Credit balance is too low
```

It authenticates with `secrets.ANTHROPIC_API_KEY`, which points at a pay-as-you-go Anthropic account that has **$0 credit**. Real CI (CI + MCP) is unaffected — this only breaks `@claude` on GitHub (e.g. the failed run on PR #64's review).

## Fix
Switch the action to a **Claude Pro/Max subscription** by reading `secrets.CLAUDE_CODE_OAUTH_TOKEN` (minted via `claude setup-token`) instead of `anthropic_api_key`. No per-use cost. `adapters/claude/README.md` §7 updated to make OAuth the primary path, API key the fallback.

## Required before `@claude` works again
This PR is the code half. The repo admin must also add the secret:
```
claude setup-token            # interactive; prints an OAuth token
gh secret set CLAUDE_CODE_OAUTH_TOKEN   # paste/pipe the token
```
Until that secret exists, the action stays broken (but it only fires on explicit `@claude`, so it blocks nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)