### PR TITLE
security(ci): author-gate Claude workflow, SHA-pin actions, contain lesson writes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,10 +13,10 @@ jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
   lint-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Orchestrator Makefile helper (drift guard)
         run: make orchestrator-help
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true
@@ -32,7 +32,7 @@ jobs:
         run: uv python install 3.13
 
       - name: Cache Hypothesis examples database
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .hypothesis
           key: hypothesis-${{ runner.os }}-${{ hashFiles('tests/test_properties.py') }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -22,28 +22,33 @@ on:
 
 jobs:
   claude:
+    # Author gate: only repo owner/members/collaborators can trigger the agent.
+    # The '@claude' mention is a string match, not an identity check — without
+    # the author_association guard, any external user could invoke a
+    # write-capable agent by commenting on an issue/PR.
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
+    # Least privilege: id-token (OIDC) dropped — auth uses CLAUDE_CODE_OAUTH_TOKEN,
+    # not cloud federation, so OIDC is unnecessary attack surface.
     permissions:
       contents: write
       pull-requests: write
       issues: write
-      id-token: write
       actions: read
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -2,8 +2,9 @@
 # Setup: https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md
 # Security: https://github.com/anthropics/claude-code-action/blob/main/docs/security.md
 #
-# ANTHROPIC_API_KEY (repository secret): GitHub web UI → this repo → Settings →
-# Secrets and variables → Actions → New repository secret. Name: ANTHROPIC_API_KEY.
+# Auth: CLAUDE_CODE_OAUTH_TOKEN (repository secret) — uses a Claude Pro/Max
+# subscription instead of pay-as-you-go API credit. Generate locally with
+# `claude setup-token`, then set it: `gh secret set CLAUDE_CODE_OAUTH_TOKEN`.
 # (Org-wide: Organization Settings → Secrets and variables → Actions.) Details:
 # adapters/claude/README.md section 7.
 
@@ -44,7 +45,7 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --max-turns 15
           plugin_marketplaces: |

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -29,10 +29,10 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           version: "latest"
           enable-cache: true
@@ -50,12 +50,12 @@ jobs:
         run: bsela --help
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
         with:
           version: 10
 

--- a/adapters/claude/README.md
+++ b/adapters/claude/README.md
@@ -85,18 +85,19 @@ Workflow: [`.github/workflows/claude.yml`](../../.github/workflows/claude.yml)
 1. Install the [Claude GitHub App](https://github.com/apps/claude) on this
    repository (or organization), per Anthropic’s
    [setup guide](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md).
-2. Add an Actions secret for the API key the workflow reads as
-   **`secrets.ANTHROPIC_API_KEY`**:
-   - **Repository secret:** open the GitHub repo in the browser → **Settings** (repo
-     settings, not your profile) → **Secrets and variables** → **Actions** →
-     **New repository secret** → Name **`ANTHROPIC_API_KEY`** → paste the key from
-     [Anthropic Console](https://console.anthropic.com/) → **Add secret**.
+2. Add an Actions secret for auth. The workflow reads
+   **`secrets.CLAUDE_CODE_OAUTH_TOKEN`** by default (Claude Pro/Max subscription —
+   no pay-as-you-go API credit needed):
+   - **OAuth (default):** run `claude setup-token` locally to mint a token, then
+     `gh secret set CLAUDE_CODE_OAUTH_TOKEN` (paste when prompted, or pipe via
+     stdin) — the token value never lands in the workflow file or git history.
+   - **Or (API key):** add **`ANTHROPIC_API_KEY`** (from
+     [Anthropic Console](https://console.anthropic.com/), pay-as-you-go credit) and
+     change the workflow step to pass
+     `anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}` instead of
+     `claude_code_oauth_token`.
    - **Organization secret (optional):** Organization **Settings** → **Secrets and
      variables** → **Actions** → new secret with the same name; grant this repo access.
-   - **Or (OAuth, Pro/Max):** add **`CLAUDE_CODE_OAUTH_TOKEN`** (from
-     `claude setup-token` locally) and change the workflow step to pass
-     `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}` instead of
-     `anthropic_api_key`.
 3. Trigger by including **`@claude`** in an issue title/body, a PR review body,
    or a PR/issue comment (see the job `if:` filter in the workflow).
 

--- a/src/bsela/core/updater.py
+++ b/src/bsela/core/updater.py
@@ -153,6 +153,12 @@ def propose_lesson(
     drafts_dir = working / DRAFTS_SUBDIR
     file_path = drafts_dir / f"{lesson.id}.md"
 
+    # Containment: lesson.id is a server-side uuid4 today, but guard against a
+    # poisoned/crafted id (e.g. path traversal) escaping the drafts directory.
+    drafts_resolved = drafts_dir.resolve()
+    if not file_path.resolve().is_relative_to(drafts_resolved):
+        raise UpdaterError(f"refusing to write lesson outside drafts dir: {lesson.id!r}")
+
     _run_git(working, "checkout", base)
     try:
         _run_git(working, "checkout", "-b", branch)

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -158,3 +158,11 @@ def test_detect_base_branch_raises_when_neither(fake_agents_md: Path) -> None:
     _run(fake_agents_md, "branch", "-m", "main", "trunk")
     with pytest.raises(UpdaterError, match="no main/master branch"):
         _detect_base_branch(fake_agents_md)
+
+
+def test_propose_lesson_rejects_traversal_id(fake_agents_md: Path) -> None:
+    """A crafted lesson.id must not escape the drafts directory."""
+    lesson = _lesson()
+    lesson.id = "../../escape"
+    with pytest.raises(UpdaterError, match="outside drafts dir"):
+        propose_lesson(lesson)


### PR DESCRIPTION
## Summary
Hardens BSELA CI/CD and the lesson-updater per the security audit. This branch also carries the prior OAuth-auth switch for the Claude action.

## Security changes
- **Author gate (claude.yml)** — every trigger now also requires `author_association ∈ {OWNER, MEMBER, COLLABORATOR}`. The `@claude` mention is a string match, not an identity check; without this guard any external user could invoke a write-capable agent by commenting.
- **Drop `id-token: write`** — auth uses `CLAUDE_CODE_OAUTH_TOKEN`, not OIDC cloud federation, so OIDC was unnecessary attack surface.
- **SHA-pin all actions** — `checkout`, `setup-uv`, `cache`, `claude-code-action`, `setup-node`, `pnpm/action-setup` pinned to commit SHAs (with `# vN` comments) across audit/ci/claude/mcp workflows. Removes mutable-tag supply-chain risk.
- **Path containment (updater.py)** — `propose_lesson` rejects a `lesson.id` that resolves outside the drafts dir (defense-in-depth; ids are uuid4 today). Regression test added.

## Auth (pre-existing on this branch)
- Switch `anthropic_api_key` → `claude_code_oauth_token` (Pro/Max subscription).

## Test
`uv run ruff check` clean; `uv run pytest tests/test_updater.py` → 11 passed; all 4 workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)