### PR TITLE
ci: auto-merge same-repo PRs once required checks pass

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,28 @@
+name: auto-merge
+
+# Enables GitHub auto-merge on same-repo PRs so they merge automatically once all
+# required status checks pass (branch protection still gates — nothing merges on red).
+# Safe by design: this workflow never checks out PR code (it only calls the API), and
+# it skips PRs from external forks, so untrusted code never runs with the write token.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only same-repo branches (owner/collaborator PRs + Dependabot); external forks are skipped.
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Enables GitHub auto-merge on non-draft same-repo PRs so they merge automatically once `lint-and-test` (and other required checks) pass. Branch protection still gates — nothing merges on red.

**Safe by design:** never checks out PR code (only calls `gh pr merge --auto`), and skips external-fork PRs, so untrusted code never runs with the write token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)