### PR TITLE
chore: cloud-readiness for Claude Code on the web

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,3 +212,6 @@ Suggested order: **1 → 2 → 3 → 4 → 5**.
 - **Prompt 5** — Fix `.github/workflows/ci.yml` / `claude.yml` if any issues remain after today's CI run.
 - **Prompt 6** — Tune `config/thresholds.toml` based on false-positive rate (12 of 33 lessons rejected = 36% rejection rate, above the target ~25%).
 - **Prompt 7** — GitHub issue sweep: run `gh issue list` and triage open issues.
+## Cloud sessions (Claude Code on the web)
+
+This repo is cloud-ready. A `SessionStart` hook (`.claude/settings.json` -> `scripts/cloud-setup.sh`) bootstraps dependencies automatically in Anthropic cloud sessions (`claude --remote`, `claude.ai/code`). It is cloud-guarded (`CLAUDE_CODE_REMOTE=true`) and a no-op in local sessions.

--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# cloud-setup.sh — dependency bootstrap for Claude Code on the web.
+# Invoked by the .claude/settings.json SessionStart hook. No-op locally:
+# runs only inside Anthropic cloud sessions (CLAUDE_CODE_REMOTE=true) and
+# installs only what a committed manifest calls for. Idempotent + safe.
+set -uo pipefail
+
+[ "${CLAUDE_CODE_REMOTE:-}" = "true" ] || exit 0
+cd "${CLAUDE_PROJECT_DIR:-$PWD}" 2>/dev/null || exit 0
+log() { printf '[cloud-setup] %s\n' "$1"; }
+
+# --- Python ---
+if [ -f pyproject.toml ]; then
+  log "pyproject.toml -> uv sync"
+  if command -v uv >/dev/null 2>&1; then
+    uv sync 2>/dev/null || uv pip install -e . 2>/dev/null || true
+  else
+    pip install -e . 2>/dev/null || true
+  fi
+fi
+if [ -f requirements.txt ]; then
+  log "requirements.txt -> pip install"
+  pip install -r requirements.txt 2>/dev/null || true
+fi
+
+# --- Node ---
+if [ -f pnpm-lock.yaml ]; then
+  log "pnpm install"; corepack enable 2>/dev/null || true
+  pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true
+elif [ -f yarn.lock ]; then
+  log "yarn install"
+  yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true
+elif [ -f package-lock.json ]; then
+  log "npm ci"; npm ci 2>/dev/null || npm install 2>/dev/null || true
+elif [ -f package.json ]; then
+  log "npm install"; npm install 2>/dev/null || true
+fi
+
+exit 0


### PR DESCRIPTION
Makes this repo cloud-ready for **Claude Code on the web** (`claude.ai/code` / `claude --remote`).

Cloud sessions are a fresh GitHub clone — local `~/.claude/` config does not travel. This commits the pieces that do:

- `.claude/settings.json` — `SessionStart` hook (`startup|resume`) that runs `scripts/cloud-setup.sh`
- `scripts/cloud-setup.sh` — dependency bootstrap. **Cloud-guarded** (`CLAUDE_CODE_REMOTE=true`) so it is a complete no-op in local sessions; auto-detects `pyproject.toml`/`requirements.txt`/`package.json` and installs accordingly. Idempotent, every command `|| true`.
- `CLAUDE.md` — added where missing / cloud note appended, so every cloud session loads project context.

No runtime/app code touched. Local workflow is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/subkoks/best-self-enhancement-learning-ai/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->