### PR TITLE
fix(hooks): make cloud-setup SessionStart hook actually ship

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/cloud-setup.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ dmypy.json
 *~
 .windsurf/
 .cursor/
-.claude/
+.claude/*
+# Keep the committed project SessionStart hook (cloud bootstrap); ignore the rest.
+!.claude/settings.json
 .codex/
 
 # macOS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,6 +212,9 @@ Suggested order: **1 → 2 → 3 → 4 → 5**.
 - **Prompt 5** — Fix `.github/workflows/ci.yml` / `claude.yml` if any issues remain after today's CI run.
 - **Prompt 6** — Tune `config/thresholds.toml` based on false-positive rate (12 of 33 lessons rejected = 36% rejection rate, above the target ~25%).
 - **Prompt 7** — GitHub issue sweep: run `gh issue list` and triage open issues.
+
+---
+
 ## Cloud sessions (Claude Code on the web)
 
 This repo is cloud-ready. A `SessionStart` hook (`.claude/settings.json` -> `scripts/cloud-setup.sh`) bootstraps dependencies automatically in Anthropic cloud sessions (`claude --remote`, `claude.ai/code`). It is cloud-guarded (`CLAUDE_CODE_REMOTE=true`) and a no-op in local sessions.


### PR DESCRIPTION
## Summary

Fixes the two `🟡` bugs Devin Review flagged on #77 (cloud-readiness for Claude Code on the web), which merged before the findings were addressed.

**Bug 1 — SessionStart hook never shipped (the script could never auto-run).** #77 documented `scripts/cloud-setup.sh` as auto-invoked by a `SessionStart` hook in `.claude/settings.json`, but `.claude/` was fully gitignored, so no such file was tracked. In a fresh cloud clone (`CLAUDE_CODE_REMOTE=true`) the file is absent and the bootstrap never fires — the repo wasn't actually "cloud-ready."

Fix: commit the project hook and narrow the ignore so only that one file is tracked.

```diff
 # .gitignore
-.claude/
+.claude/*
+!.claude/settings.json
```
```json
// .claude/settings.json (new, tracked)
{ "hooks": { "SessionStart": [
  { "matcher": "startup|resume",
    "hooks": [ { "type": "command", "command": "bash scripts/cloud-setup.sh" } ] } ] } }
```

`.claude/*` (not `.claude/`) is required so git can re-include a file via the `!` negation — a fully-ignored *directory* cannot have its contents re-included. The rest of `.claude/` (e.g. the gitignored `settings.local.json` permissions file from the manual workflow) stays ignored. This is the repo-local *project* settings file, distinct from `~/.claude/settings.json` (home, used by the documented Stop-hook workflow), so the existing local setup in `adapters/claude/README.md` is untouched. The hook itself is cloud-guarded (`cloud-setup.sh` exits 0 immediately unless `CLAUDE_CODE_REMOTE=true`), so it remains a no-op locally.

**Bug 2 — heading not separated from preceding list.** The `## Cloud sessions` heading in `CLAUDE.md` abutted the prior bullet with no separator, unlike every other top-level section (each preceded by a `---` rule). Added the rule + blank lines.

The 3 remaining `📝` review comments were informational (intentional `|| true` best-effort design, `pipefail`-without-`-e`, independent Python install blocks) and require no change.

No runtime/app code touched; Python CI surface is unaffected.


Link to Devin session: https://app.devin.ai/sessions/f20bce13991f46b28f034473a43cb598
Requested by: @subkoks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/subkoks/best-self-enhancement-learning-ai/pull/78" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->