### PR TITLE
fix(hooks): install mcp/ Node deps in cloud bootstrap

### DIFF
--- a/scripts/cloud-setup.sh
+++ b/scripts/cloud-setup.sh
@@ -24,16 +24,27 @@ if [ -f requirements.txt ]; then
 fi
 
 # --- Node ---
-if [ -f pnpm-lock.yaml ]; then
-  log "pnpm install"; corepack enable 2>/dev/null || true
-  pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null || true
-elif [ -f yarn.lock ]; then
-  log "yarn install"
-  yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null || true
-elif [ -f package-lock.json ]; then
-  log "npm ci"; npm ci 2>/dev/null || npm install 2>/dev/null || true
-elif [ -f package.json ]; then
-  log "npm install"; npm install 2>/dev/null || true
-fi
+# Install Node deps for a directory, picking the manager from its lockfile.
+node_install() {
+  dir="$1"
+  [ -f "$dir/package.json" ] || return 0
+  if [ -f "$dir/pnpm-lock.yaml" ]; then
+    log "$dir -> pnpm install"; corepack enable 2>/dev/null || true
+    (cd "$dir" && { pnpm install --frozen-lockfile 2>/dev/null || pnpm install 2>/dev/null; }) || true
+  elif [ -f "$dir/yarn.lock" ]; then
+    log "$dir -> yarn install"
+    (cd "$dir" && { yarn install --frozen-lockfile 2>/dev/null || yarn install 2>/dev/null; }) || true
+  elif [ -f "$dir/package-lock.json" ]; then
+    log "$dir -> npm ci"
+    (cd "$dir" && { npm ci 2>/dev/null || npm install 2>/dev/null; }) || true
+  else
+    log "$dir -> npm install"
+    (cd "$dir" && npm install 2>/dev/null) || true
+  fi
+}
+
+# Root, then known workspaces (BSELA's MCP server lives in mcp/).
+node_install .
+node_install mcp
 
 exit 0


### PR DESCRIPTION
## Summary

Follow-up to the Devin Review `🚩` on #78: `scripts/cloud-setup.sh`'s Node block only inspected the repo root, but BSELA's only Node project is the MCP server under `mcp/` (`mcp/pnpm-lock.yaml`). There is no root `package.json`/lockfile, so the entire Node block was dead — cloud sessions never installed MCP deps, undercutting the "cloud-ready" goal for the MCP path.

Refactor the per-manager selection into a `node_install <dir>` helper and run it for both the root and `mcp/`:

```bash
node_install() {
  dir="$1"
  [ -f "$dir/package.json" ] || return 0
  # pnpm-lock.yaml -> pnpm | yarn.lock -> yarn | package-lock.json -> npm ci | else npm install
  # each runs in a (cd "$dir" && ...) subshell, suppressed and `|| true`
}
node_install .
node_install mcp
```

Behavior preserved: cloud-guarded (no-op unless `CLAUDE_CODE_REMOTE=true`), idempotent, every command best-effort (`|| true`) so a missing manager or failed install never blocks session start.

Verified with `bash -n`, `shellcheck` (clean), and a simulated run against a fixture `mcp/package.json` + `mcp/pnpm-lock.yaml` (logs `mcp -> pnpm install`, exits 0).


Link to Devin session: https://app.devin.ai/sessions/f20bce13991f46b28f034473a43cb598
Requested by: @subkoks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/subkoks/best-self-enhancement-learning-ai/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->