### PR TITLE
fix(ci): add id-token: write so Claude Code action can fetch OIDC token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,13 +32,15 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association)) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.issue.author_association))
     runs-on: ubuntu-latest
-    # Least privilege: id-token (OIDC) dropped — auth uses CLAUDE_CODE_OAUTH_TOKEN,
-    # not cloud federation, so OIDC is unnecessary attack surface.
+    # id-token: write is required even though auth is the OAuth token: the
+    # claude-code-action fetches a GitHub OIDC token at startup and fails
+    # (ACTIONS_ID_TOKEN_REQUEST_URL missing) without this permission.
     permissions:
       contents: write
       pull-requests: write
       issues: write
       actions: read
+      id-token: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- The `Claude Code` workflow can't start: `anthropics/claude-code-action` requests a GitHub Actions OIDC token at startup and the job lacks `id-token: write`.

## Why
- Without `id-token: write`, `ACTIONS_ID_TOKEN_REQUEST_URL` is not injected and the action fails immediately with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL`, before any auth. This occurs even though auth is via `CLAUDE_CODE_OAUTH_TOKEN` (not cloud federation). Mirrors the fix already merged in `subkoks/subkoks`.

## Changes
- Add `id-token: write` to the `claude` job `permissions`.
- Replace the now-inaccurate "id-token (OIDC) dropped" comment with the reason it is required.

```diff
       actions: read
+      id-token: write
```

## Test plan
- [x] Local checks pass (YAML valid)
- [ ] Behavior verified (requires `CLAUDE_CODE_OAUTH_TOKEN` secret, added separately)

## Risks
- Minimal: grants the job an OIDC token. The action already expects it; no other behavior changes.

Link to Devin session: https://app.devin.ai/sessions/703f0fe6bfa2463bad5e7f2a681b21fc
Requested by: @subkoks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/subkoks/best-self-enhancement-learning-ai/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->