### PR TITLE
chore(models): add Claude Fable 5 / Mythos 5 to the model registry

### DIFF
--- a/src/bsela/llm/client.py
+++ b/src/bsela/llm/client.py
@@ -43,11 +43,12 @@ _DETERMINISTIC_TEMPERATURE = 0.0
 _DETERMINISTIC_SEED = 42
 
 # Anthropic returns HTTP 400 for a non-default ``temperature``/``top_p``/``top_k``
-# on Claude Opus 4.7 and later (incl. 4.8), so the kwarg must be omitted for those
-# models. Anthropic also ignores ``seed``, so determinism on Opus 4.7+ must come
-# from the prompt, not sampling params. Matches 4.7-4.99; a future Opus 5.x would
+# on Claude Opus 4.7 and later (incl. 4.8) and on the Claude 5 family (Fable 5 /
+# Mythos 5), so the kwarg must be omitted for those models. Anthropic also ignores
+# ``seed``, so determinism on these models must come from the prompt, not sampling
+# params. Matches Opus 4.7-4.99 plus fable-5/mythos-5; a future Opus 5.x would
 # need adding here.
-_OMIT_SAMPLING = re.compile(r"claude-opus-4-(?:[7-9]|\d\d)")
+_OMIT_SAMPLING = re.compile(r"claude-(?:opus-4-(?:[7-9]|\d\d)|fable-5|mythos-5)")
 
 
 def _extract_json_object(text: str) -> str:

--- a/tests/test_models_config.py
+++ b/tests/test_models_config.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 from bsela.utils.config import ModelRole, load_models
 
-# Active Anthropic model ids (checked 2026-05-31). Add ids here when adopting them.
+# Active Anthropic model ids (checked 2026-06-12). Add ids here when adopting them.
 CURRENT_ANTHROPIC_MODELS = frozenset(
     {
+        "claude-fable-5",
+        "claude-mythos-5",
         "claude-opus-4-8",
         "claude-opus-4-7",
         "claude-opus-4-6",


### PR DESCRIPTION
## What

- Add `claude-fable-5` and `claude-mythos-5` to `CURRENT_ANTHROPIC_MODELS` in `tests/test_models_config.py` so the CI guard permits adopting them in `models.toml`.
- Widen `_OMIT_SAMPLING` in `src/bsela/llm/client.py` to also match the Claude 5 family — `temperature`/`top_p`/`top_k` return HTTP 400 on Fable 5/Mythos 5 exactly as on Opus 4.7+, so the kwargs must be omitted.

## Why

Part of the Fable 5 migration plan (`~/.claude/plans/fable-5-migration.md`). Without the regex fix, the first `BSELA_MODEL_PLANNER=claude-fable-5` override would 400 because `models.toml` sets per-role temperatures.

## Notes

- Role routing intentionally unchanged (judge=haiku, distiller/planner=opus-4-8, builder=sonnet) — right cost profile for a background pipeline; Fable 5 is 2× Opus pricing.
- Follow-up before defaulting any role to Fable 5: handle `stop_reason == "refusal"` in the client (Fable 5 safety classifiers return HTTP 200 + refusal).
- Tests: `uv run --extra dev pytest tests/test_models_config.py tests/test_llm_client.py` → 25 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/subkoks/best-self-enhancement-learning-ai/pull/81" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->