### PR TITLE
ci: skip Claude Auto PR Review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,7 +30,7 @@ jobs:
   # ─── AUTO review on every PR ───────────────────────────────────────────────
   claude-pr-review:
     name: Auto PR Review
-    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
The **Auto PR Review** job (`claude-pr-review`) authenticates via the `CLAUDE_CODE_OAUTH_TOKEN` secret. Dependabot PRs run **without access to repository secrets**, so the token is empty and the job fails on every Dependabot PR (it is non-required, so it doesn't block merges — just noise + red checks).

This guards the job with `github.actor != 'dependabot[bot]'` so it skips on Dependabot PRs. The manual `@claude` job and normal human PR reviews are unaffected. Identical change applied fleet-wide across all repos carrying this templated workflow.

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
