### PR TITLE
fix(claude): use make targets in agent check commands

### DIFF
--- a/.claude/agents/bsela-implementer.md
+++ b/.claude/agents/bsela-implementer.md
@@ -13,6 +13,6 @@ Rules:
 - Read AGENTS first, then target files.
 - Prefer edits over new files.
 - Keep one logical change at a time.
-- Run only necessary checks (`uv run pytest -q` for Python, `cd mcp && pnpm check` for MCP).
+- Run only necessary checks (`make cov` for Python, `make mcp-check` for MCP).
 - Never touch synced editor artifacts (`~/.claude/CLAUDE.md`, `~/.cursor/*`, etc.).
 - Output: changed files + why + commands run + result.

--- a/.claude/agents/bsela-ops-checker.md
+++ b/.claude/agents/bsela-ops-checker.md
@@ -11,7 +11,7 @@ You run quick operational checks and report actionable failures only.
 Default checks:
 - `uv run bsela doctor`
 - repo status/upstream (`git status -sb`)
-- if MCP touched: `cd mcp && pnpm check`
+- if MCP touched: `make mcp-check`
 
 Output:
 - PASS/FAIL table


### PR DESCRIPTION
## Summary

- `bsela-implementer`: replace `uv run pytest -q` → `make cov` (enforces `--cov-fail-under=99` matching CI) and `cd mcp && pnpm check` → `make mcp-check` (`pnpm check + pnpm build`; bare `pnpm check` left `dist/server.js` stale)
- `bsela-ops-checker`: same `cd mcp && pnpm check` → `make mcp-check` fix

Found by code review of PR #90 agent definitions.

## Test plan

- [ ] CI `lint-and-test` green
- [ ] Verify `make cov` runs `--cov-fail-under=99`
- [ ] Verify `make mcp-check` runs `pnpm check && pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)