### PR TITLE
fix(claude): clean up agent definitions (path, memory field, gitignore depth)

### DIFF
--- a/.claude/agents/bsela-implementer.md
+++ b/.claude/agents/bsela-implementer.md
@@ -13,6 +13,6 @@ Rules:
 - Read AGENTS first, then target files.
 - Prefer edits over new files.
 - Keep one logical change at a time.
-- Run only necessary checks (`uv run pytest -q` for Python, `cd mcp && pnpm check` for MCP).
+- Run only necessary checks (`make cov` for Python, `make mcp-check` for MCP).
 - Never touch synced editor artifacts (`~/.claude/CLAUDE.md`, `~/.cursor/*`, etc.).
 - Output: changed files + why + commands run + result.

--- a/.claude/agents/bsela-implementer.md
+++ b/.claude/agents/bsela-implementer.md
@@ -9,7 +9,7 @@ color: blue
 You implement requested changes in BSELA with tight diffs.
 
 Rules:
-- Scope: `/Users/black.terminal/Projects/Current/Active/BEST-Self-Enhancement-Learning-AI`.
+- Scope: this repo root (read AGENTS.md to orient before touching files).
 - Read AGENTS first, then target files.
 - Prefer edits over new files.
 - Keep one logical change at a time.

--- a/.claude/agents/bsela-ops-checker.md
+++ b/.claude/agents/bsela-ops-checker.md
@@ -11,7 +11,7 @@ You run quick operational checks and report actionable failures only.
 Default checks:
 - `uv run bsela doctor`
 - repo status/upstream (`git status -sb`)
-- if MCP touched: `cd mcp && pnpm check`
+- if MCP touched: `make mcp-check`
 
 Output:
 - PASS/FAIL table

--- a/.claude/agents/bsela-reviewer.md
+++ b/.claude/agents/bsela-reviewer.md
@@ -4,7 +4,6 @@ description: Readonly bug/regression reviewer for BSELA diffs. Fast severity-ran
 tools: Read, Glob, Grep, Bash
 model: sonnet
 color: yellow
-memory: project
 ---
 
 You review staged/unstaged diff in readonly mode.

--- a/.gitignore
+++ b/.gitignore
@@ -94,4 +94,4 @@ site/
 .claude/*
 !.claude/settings.json
 !.claude/agents/
-!.claude/agents/*
+!.claude/agents/**


### PR DESCRIPTION
## Summary

Low-severity findings from the PR #90 code review:

- **bsela-implementer**: hardcoded absolute path `/Users/black.terminal/...` → portable `this repo root` description (breaks in cloud sessions / other checkouts)
- **bsela-reviewer**: remove `memory: project` frontmatter — `memory:` is not a Claude Code subagent field and is silently ignored by the runtime
- **.gitignore**: `!.claude/agents/*` → `!.claude/agents/**` so nested agent paths (e.g. `agents/v2/`) are tracked without needing `-f`

## Test plan

- [ ] CI `lint-and-test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)