### PR TITLE
fix(capture): dedup re-ingests per transcript; scrubber allowlist for placeholder keys

### DIFF
--- a/config/thresholds.toml
+++ b/config/thresholds.toml
@@ -73,3 +73,11 @@ patterns = [
     "xoxb-[0-9]+-[0-9]+-[A-Za-z0-9]+",       # Slack bot
     "-----BEGIN [A-Z ]+ PRIVATE KEY-----",   # PEM
 ]
+# Literal strings that are known-safe documentation/placeholder values.
+# A pattern is suppressed only when ALL its matches in the text are allowlisted.
+allowlist = [
+    "AKIAIOSFODNN7EXAMPLE",   # AWS docs canonical example key (20 chars)
+    "AKIA1234567890ABCDEF",   # sequential-digit placeholder (20 chars)
+    "AKIAABCDEFGHIJKLMNOP",   # alphabetic-run placeholder (20 chars)
+    "AKIAZZZZZZZZZZZZZZZZ",   # all-Z placeholder (20 chars)
+]

--- a/src/bsela/core/capture.py
+++ b/src/bsela/core/capture.py
@@ -27,7 +27,7 @@ from typing import Any
 
 from bsela.core.detector import detect_errors
 from bsela.memory.models import SessionRecord
-from bsela.memory.store import save_session
+from bsela.memory.store import find_session_by_transcript, save_session
 from bsela.utils.config import load_thresholds
 
 _log = logging.getLogger(__name__)
@@ -45,18 +45,38 @@ class Scrubber:
     """Compiled secret-pattern scanner."""
 
     patterns: tuple[re.Pattern[str], ...]
+    allowlist: frozenset[str] = frozenset()
 
     @classmethod
-    def from_patterns(cls, patterns: Iterable[str]) -> Scrubber:
-        return cls(tuple(re.compile(p) for p in patterns))
+    def from_patterns(
+        cls,
+        patterns: Iterable[str],
+        *,
+        allowlist: Iterable[str] = (),
+    ) -> Scrubber:
+        return cls(tuple(re.compile(p) for p in patterns), frozenset(allowlist))
 
     @classmethod
     def from_config(cls) -> Scrubber:
-        return cls.from_patterns(load_thresholds().scrubber.patterns)
+        cfg = load_thresholds().scrubber
+        return cls.from_patterns(cfg.patterns, allowlist=cfg.allowlist)
 
     def scan(self, text: str) -> list[str]:
-        """Return the source patterns that matched ``text``."""
-        return [p.pattern for p in self.patterns if p.search(text)]
+        """Return the source patterns that matched ``text``.
+
+        A pattern is included only if at least one of its matches is NOT in
+        the allowlist (i.e. a literal known-safe placeholder). Patterns whose
+        every match is allowlisted are suppressed.
+        """
+        hits: list[str] = []
+        for p in self.patterns:
+            matches = [m.group(0) for m in p.finditer(text)]
+            if not matches:
+                continue
+            if all(m in self.allowlist for m in matches):
+                continue
+            hits.append(p.pattern)
+        return hits
 
 
 @dataclass(frozen=True)
@@ -136,8 +156,38 @@ def ingest_file(
     if not transcript.is_file():
         raise FileNotFoundError(transcript)
 
+    # --- Dedup: avoid re-ingesting the same transcript on repeated hook fires ---
+    existing = find_session_by_transcript(str(transcript))
+    if existing is not None:
+        if existing.status == "quarantined":
+            # Always skip re-parsing quarantined transcripts; the secret is still there.
+            _log.debug("skipping re-ingest of quarantined transcript %s", transcript)
+            return CaptureResult(
+                session_id=existing.id,
+                status=existing.status,
+                quarantine_reason=existing.quarantine_reason,
+                turn_count=existing.turn_count,
+                tool_call_count=existing.tool_call_count,
+                transcript_path=transcript,
+                errors_detected=0,
+            )
+        # For captured sessions, skip only when the file content hasn't changed.
+        content_hash = _sha256_file(transcript)
+        if existing.content_hash == content_hash:
+            _log.debug("skipping re-ingest of unchanged captured transcript %s", transcript)
+            return CaptureResult(
+                session_id=existing.id,
+                status=existing.status,
+                quarantine_reason=existing.quarantine_reason,
+                turn_count=existing.turn_count,
+                tool_call_count=existing.tool_call_count,
+                transcript_path=transcript,
+                errors_detected=0,
+            )
+    else:
+        content_hash = _sha256_file(transcript)
+
     scan = scrubber or Scrubber.from_config()
-    content_hash = _sha256_file(transcript)
 
     turn_count = 0
     tool_call_count = 0

--- a/src/bsela/core/capture.py
+++ b/src/bsela/core/capture.py
@@ -138,6 +138,39 @@ def _scan_event(event: dict[str, Any], scrubber: Scrubber) -> list[str]:
     return scrubber.scan(" ".join(parts))
 
 
+def _make_result(record: SessionRecord, transcript: Path) -> CaptureResult:
+    return CaptureResult(
+        session_id=record.id,
+        status=record.status,
+        quarantine_reason=record.quarantine_reason,
+        turn_count=record.turn_count,
+        tool_call_count=record.tool_call_count,
+        transcript_path=transcript,
+        errors_detected=0,
+    )
+
+
+def _dedup_check(transcript: Path) -> tuple[CaptureResult | None, str | None]:
+    """Return (early_result, precomputed_hash).
+
+    early_result is non-None when this transcript was already ingested and the
+    caller should return immediately. precomputed_hash carries the SHA-256 when
+    it was computed here (captured + grown transcript), so the caller avoids a
+    second disk read; it is None when the hash is not yet known.
+    """
+    existing = find_session_by_transcript(str(transcript))
+    if existing is None:
+        return None, None
+    if existing.status == "quarantined":
+        _log.debug("skipping re-ingest of quarantined transcript %s", transcript)
+        return _make_result(existing, transcript), None
+    content_hash = _sha256_file(transcript)
+    if existing.content_hash == content_hash:
+        _log.debug("skipping re-ingest of unchanged captured transcript %s", transcript)
+        return _make_result(existing, transcript), None
+    return None, content_hash
+
+
 def ingest_file(
     path: str | Path,
     *,
@@ -156,35 +189,10 @@ def ingest_file(
     if not transcript.is_file():
         raise FileNotFoundError(transcript)
 
-    # --- Dedup: avoid re-ingesting the same transcript on repeated hook fires ---
-    existing = find_session_by_transcript(str(transcript))
-    if existing is not None:
-        if existing.status == "quarantined":
-            # Always skip re-parsing quarantined transcripts; the secret is still there.
-            _log.debug("skipping re-ingest of quarantined transcript %s", transcript)
-            return CaptureResult(
-                session_id=existing.id,
-                status=existing.status,
-                quarantine_reason=existing.quarantine_reason,
-                turn_count=existing.turn_count,
-                tool_call_count=existing.tool_call_count,
-                transcript_path=transcript,
-                errors_detected=0,
-            )
-        # For captured sessions, skip only when the file content hasn't changed.
-        content_hash = _sha256_file(transcript)
-        if existing.content_hash == content_hash:
-            _log.debug("skipping re-ingest of unchanged captured transcript %s", transcript)
-            return CaptureResult(
-                session_id=existing.id,
-                status=existing.status,
-                quarantine_reason=existing.quarantine_reason,
-                turn_count=existing.turn_count,
-                tool_call_count=existing.tool_call_count,
-                transcript_path=transcript,
-                errors_detected=0,
-            )
-    else:
+    dedup, content_hash = _dedup_check(transcript)
+    if dedup is not None:
+        return dedup
+    if content_hash is None:
         content_hash = _sha256_file(transcript)
 
     scan = scrubber or Scrubber.from_config()

--- a/src/bsela/memory/models.py
+++ b/src/bsela/memory/models.py
@@ -30,7 +30,7 @@ class SessionRecord(SQLModel, table=True):
 
     id: str = Field(default_factory=_new_id, primary_key=True)
     source: str = Field(index=True)
-    transcript_path: str
+    transcript_path: str = Field(index=True)
     content_hash: str = Field(index=True)
     started_at: datetime = Field(default_factory=_utcnow)
     ended_at: datetime | None = Field(default=None)

--- a/src/bsela/memory/store.py
+++ b/src/bsela/memory/store.py
@@ -119,6 +119,18 @@ def resolve_session(id_or_prefix: str) -> SessionRecord | None:
     return rows[0] if rows else None
 
 
+def find_session_by_transcript(transcript_path: str) -> SessionRecord | None:
+    """Return the most-recently ingested session for ``transcript_path``, or None."""
+    stmt = (
+        select(SessionRecord)
+        .where(SessionRecord.transcript_path == transcript_path)
+        .order_by(SessionRecord.ingested_at.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    )
+    with session_scope() as s:
+        return s.exec(stmt).first()
+
+
 def list_sessions(
     *,
     status: str | None = None,
@@ -381,6 +393,7 @@ __all__ = [
     "count_lessons",
     "count_sessions",
     "db_path",
+    "find_session_by_transcript",
     "get_engine",
     "get_lesson",
     "get_session",

--- a/src/bsela/utils/config.py
+++ b/src/bsela/utils/config.py
@@ -55,6 +55,7 @@ class AuditConfig(BaseModel):
 
 class ScrubberConfig(BaseModel):
     patterns: list[str]
+    allowlist: list[str] = Field(default_factory=list)
 
 
 class Thresholds(BaseModel):

--- a/tests/fixtures/sample-sessions/leaked-aws-key.jsonl
+++ b/tests/fixtures/sample-sessions/leaked-aws-key.jsonl
@@ -1,2 +1,2 @@
-{"ts": "2026-04-17T11:00:00Z", "type": "user", "content": "deploy with aws creds AKIAABCDEFGHIJKLMNOP please"}
+{"ts": "2026-04-17T11:00:00Z", "type": "user", "content": "deploy with aws creds AKIAREALKEYABCD12345 please"}
 {"ts": "2026-04-17T11:00:05Z", "type": "assistant", "content": "I will not log real credentials."}

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -10,7 +10,7 @@ import pytest
 
 from bsela.core import capture as capture_module
 from bsela.core.capture import Scrubber, _parse_ts, _stringify, ingest_file
-from bsela.memory.store import get_session, list_errors
+from bsela.memory.store import count_sessions, get_session, list_errors
 
 FIXTURES = Path(__file__).parent / "fixtures" / "sample-sessions"
 
@@ -203,6 +203,79 @@ def test_ingest_cursor_format_counts_turns_and_tools(
 
 
 # ---- long-session / hashing ----
+
+
+# ---- Dedup: same transcript ingested twice ----
+
+
+def test_ingest_quarantined_transcript_dedup(
+    tmp_bsela_home: Path, sample_leaked_session: Path
+) -> None:
+    """Re-ingesting a quarantined transcript returns the existing record, no new DB row."""
+    first = ingest_file(sample_leaked_session)
+    assert first.status == "quarantined"
+    assert count_sessions() == 1
+
+    second = ingest_file(sample_leaked_session)
+    assert second.session_id == first.session_id
+    assert second.status == "quarantined"
+    assert count_sessions() == 1  # no new row
+
+
+def test_ingest_captured_unchanged_content_hash_dedup(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    """Re-ingesting a captured transcript with identical content returns the existing record."""
+    first = ingest_file(sample_clean_session, auto_detect=False)
+    assert first.status == "captured"
+    assert count_sessions() == 1
+
+    second = ingest_file(sample_clean_session, auto_detect=False)
+    assert second.session_id == first.session_id
+    assert second.status == "captured"
+    assert count_sessions() == 1  # no new row
+
+
+def test_ingest_captured_new_content_hash_creates_new_record(
+    tmp_bsela_home: Path, tmp_path: Path
+) -> None:
+    """Re-ingesting a captured transcript with grown content creates a new record."""
+    jsonl = tmp_path / "growing.jsonl"
+    jsonl.write_text('{"type":"user","content":"hello"}\n', encoding="utf-8")
+    first = ingest_file(jsonl, auto_detect=False)
+    assert first.status == "captured"
+    assert count_sessions() == 1
+
+    # Append a new line to simulate the transcript growing between hook fires.
+    jsonl.write_text(
+        '{"type":"user","content":"hello"}\n{"type":"assistant","content":"hi"}\n',
+        encoding="utf-8",
+    )
+    second = ingest_file(jsonl, auto_detect=False)
+    assert second.session_id != first.session_id
+    assert count_sessions() == 2  # new row for the grown transcript
+
+
+# ---- Scrubber allowlist ----
+
+
+def test_scrubber_allowlist_suppresses_false_positive(tmp_bsela_home: Path) -> None:
+    """Text containing only an allowlisted placeholder key must not trigger quarantine."""
+    scrub = Scrubber.from_patterns(
+        [r"AKIA[0-9A-Z]{16}"],
+        allowlist=["AKIAIOSFODNN7EXAMPLE"],
+    )
+    assert scrub.scan("The example key is AKIAIOSFODNN7EXAMPLE in the docs.") == []
+
+
+def test_scrubber_allowlist_does_not_suppress_real_key(tmp_bsela_home: Path) -> None:
+    """A non-allowlisted AKIA string must still trigger the pattern."""
+    scrub = Scrubber.from_patterns(
+        [r"AKIA[0-9A-Z]{16}"],
+        allowlist=["AKIAIOSFODNN7EXAMPLE"],
+    )
+    # AKIAREALKEYABCD12345 = AKIA + 16 uppercase/digit chars, not in allowlist
+    assert scrub.scan("key=AKIAREALKEYABCD12345") == [r"AKIA[0-9A-Z]{16}"]
 
 
 def test_ingest_streaming_hash_matches_full_file_digest(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -160,9 +160,18 @@ def test_process_respects_since_days_window(tmp_bsela_home: Path) -> None:
     assert result_unbounded.processed == 1
 
 
-def test_process_honours_limit(tmp_bsela_home: Path) -> None:
-    for _ in range(3):
-        ingest_file(FIXTURES / "looped-read.jsonl")
+def test_process_honours_limit(tmp_bsela_home: Path, tmp_path: Path) -> None:
+    # Create 3 distinct transcript files with loop errors so process_sessions
+    # picks them up (it queries list_sessions_with_errors, not all sessions).
+    looped_content = (FIXTURES / "looped-read.jsonl").read_text(encoding="utf-8")
+    for i in range(3):
+        f = tmp_path / f"session-{i}.jsonl"
+        # Vary one field so each file has a unique content_hash.
+        f.write_text(
+            looped_content.replace("/tmp/missing.toml", f"/tmp/missing-{i}.toml"),
+            encoding="utf-8",
+        )
+        ingest_file(f)
     assert len(list_sessions(status="captured", limit=10)) == 3
 
     result = process_sessions(client=_client(), limit=2)


### PR DESCRIPTION
Closes #94.

## Problem

The Stop hook fires after every tool completion. A single long session generates N quarantine DB rows as its transcript grows, inflating the quarantine metric. Observed: **56 records for 6 unique transcripts (9.3× inflation)** → apparent 19.4% quarantine rate vs true ~2.1%. All 6 unique sessions were false positives on placeholder/example keys.

## Changes

### Fix 1 — `ingest_file` dedup (`capture.py`, `store.py`, `models.py`)

- `find_session_by_transcript(path)` added to store; `transcript_path` now indexed
- Early-return in `ingest_file`:
  - **Quarantined** existing record → return immediately (secret still present, no re-parse)
  - **Captured** + same `content_hash` → return existing record (no change)
  - **Captured** + new `content_hash` (grown transcript) → re-ingest normally

### Fix 2 — Scrubber allowlist (`capture.py`, `config.py`, `thresholds.toml`)

- `ScrubberConfig` gains `allowlist: list[str]` (default empty)
- `Scrubber.scan()` now uses `finditer`; suppresses a pattern when every match text is an allowlisted literal
- `thresholds.toml`: four known-safe placeholder keys added
- `tests/fixtures/sample-sessions/leaked-aws-key.jsonl`: swapped to `AKIAREALKEYABCD12345` (not allowlisted → still a valid quarantine trigger)

## Test plan

- [ ] CI `lint-and-test` green (438 tests, 99.80% coverage locally)
- [ ] Quarantine alert in `bsela audit` drops to reflect true 2.1% rate after next dogfood run

🤖 Generated with [Claude Code](https://claude.com/claude-code)