### PR TITLE
fix(security): bump hono override to >=4.12.25 (Dependabot #19-#23)

### DIFF
--- a/mcp/pnpm-lock.yaml
+++ b/mcp/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   fast-uri: '>=3.1.2'
   ip-address: '>=10.1.1'
-  hono: '>=4.12.21'
+  hono: '>=4.12.25'
   qs: '>=6.15.2'
   vite: 7.3.5
   esbuild: '>=0.28.1'
@@ -261,7 +261,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.21'
+      hono: '>=4.12.25'
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -858,8 +858,8 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -1468,9 +1468,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.26)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.26
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1499,7 +1499,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.26)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -1509,7 +1509,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.4.1(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.26
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -2108,7 +2108,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.12.23: {}
+  hono@4.12.26: {}
 
   html-escaper@2.0.2: {}
 

--- a/mcp/pnpm-workspace.yaml
+++ b/mcp/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
 overrides:
   fast-uri: ">=3.1.2"
   ip-address: ">=10.1.1"
-  hono: ">=4.12.21"
+  hono: ">=4.12.25"
   qs: ">=6.15.2"
   vite: "7.3.5"
   esbuild: ">=0.28.1"


### PR DESCRIPTION
Closes Dependabot alerts **#19–#23** (all hono, patched in 4.12.25):

| # | Severity | Issue |
|---|---|---|
| #21 | High | CORS wildcard reflects any Origin with credentials |
| #19 | Medium | Lambda adapter drops `Set-Cookie` headers on ALB |
| #20 | Medium | `serve-static` path traversal on Windows via `%5C` |
| #22 | Medium | Lambda@Edge drops repeated request headers |
| #23 | Medium | Body-limit bypass on AWS Lambda via under-reported `Content-Length` |

**Change:** `pnpm-workspace.yaml` `hono: ">=4.12.21"` → `">=4.12.25"`. Resolves to 4.12.26 (latest). `mcp-check` passes (59 TS tests, build clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)