### PR TITLE
chore(docs): note Cursor adapter retired 2026-06-17

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ and [`docs/orchestrator/README.md`](docs/orchestrator/README.md) (ADR
 [0008](docs/decisions/0008-developer-orchestrator-workflow.md); Agent SDK posture:
 [0009](docs/decisions/0009-claude-agent-sdk-non-adoption.md)).
 
-For **Cursor** (MCP wiring), see [`adapters/cursor/README.md`](adapters/cursor/README.md) and the editor index in [`adapters/README.md`](adapters/README.md).
+~~For **Cursor** (MCP wiring), see [`adapters/cursor/README.md`](adapters/cursor/README.md)~~ — Cursor retired 2026-06-17; adapter preserved as reference in [`adapters/README.md`](adapters/README.md).
 
 For Codex CLI continuation from this repo, see [`CODEX.md`](CODEX.md).
 


### PR DESCRIPTION
## Summary
- Strike through the Cursor MCP wiring line and add retirement note
- Cursor/Windsurf retired 2026-06-17; adapter preserved for reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)