### PR TITLE
feat(audit): externalized lesson status — end the false-positive DRIFT alert

### DIFF
--- a/docs/decisions/0011-externalized-lesson-status.md
+++ b/docs/decisions/0011-externalized-lesson-status.md
@@ -1,0 +1,83 @@
+# ADR 0011 — `externalized` terminal lesson status (drift gate vs. dedup corpus)
+
+- **Status:** Accepted
+- **Date:** 2026-06-22
+
+## Context
+
+`bsela audit` raised a **blocking** DRIFT alert every run:
+`DRIFT: 3/3 applied lessons unused for 14+ days (100.0% > 50.0% threshold)`.
+
+The three `applied` lessons (`55adbcb3`, `809875ce`, `6a6601cb`) were promoted
+into the `agents-md` `AGENTS.md` distilled-lessons section via PR #31 and
+reconciled `proposed → applied` on 2026-06-20. The drift detector
+(`core/auditor.py`) counts lessons in `("applied","approved")` with
+`hit_count == 0` older than `STALE_LESSON_AGE_DAYS` (14) as stale.
+
+A lesson's `hit_count` only increments through `bsela lessons --bump`
+(`cli.py` → `store.increment_hit_count`), i.e. when BSELA surfaces the lesson to
+an editor. Once a lesson is externalized into `AGENTS.md`, the editor reads it
+directly as a durable rule — BSELA never surfaces it, so it can **never** accrue
+a hit. These lessons are therefore permanently `hit_count == 0` and permanently
+"stale" by the metric. The alert is a structural false-positive: it fires at
+100% on every audit regardless of real drift, training the operator to ignore the
+auditor.
+
+The pre-existing terminal status `rolled_back` is excluded from audit counts, but
+it cannot be reused here: the distiller dedup corpus
+(`llm/distiller.py`) is built from `approved` + `applied` lessons only, and
+rolling these back would drop them from that corpus — so the distiller would
+regenerate the very rules that already live in `AGENTS.md` as fresh candidates.
+
+## Decision
+
+1. **Introduce a new terminal lesson status, `externalized`,** for lessons that
+   have graduated into `agents-md` as durable rules. `status` is a plain `str`
+   column — no schema migration.
+
+2. **Externalized lessons leave the drift gate.** `auditor.py` keeps
+   `tracked_statuses = ("applied","approved")`, so `externalized` is excluded
+   from `lessons_total`/`lessons_stale` automatically. A new
+   `DriftSnapshot.lessons_externalized` count is computed and rendered
+   (`## Drift → Externalized (durable in agents-md): N`) and is present in the
+   `--json` payload, so the lessons remain visible, just not gated.
+
+3. **Externalized lessons stay in the distiller dedup corpus.** This is the one
+   behavioural difference from `rolled_back`: `distill_session` now includes
+   `list_lessons(status="externalized")` in `approved_corpus`, so a candidate
+   duplicating an externalized rule is still suppressed.
+
+4. **Transition is operator-driven** via a new `bsela externalize <id>` command
+   (mirrors `bsela rollback`: `resolve_lesson` → `update_lesson_status`). The
+   three lessons above are migrated `applied → externalized`. The MCP
+   `bsela_lessons` status enum gains `externalized` for parity. `trackHits`
+   (MCP) deliberately does **not** include `externalized` — they cannot be hit.
+
+## Consequences
+
+- The weekly audit stops permanently red on the externalized-lessons
+  false-positive while still surfacing genuine staleness of any future
+  `applied`/`approved` lesson that goes unused.
+- Dedup integrity is preserved: externalized rules cannot be regenerated as
+  duplicate candidates (regression-tested).
+- The drift metric now has an honest population — only lessons that *could*
+  realistically accrue hits are gated.
+- Reversible: `externalized` is a status string; a lesson can be moved back, and
+  removing the status from the dedup corpus query is a one-line revert.
+
+## Rejected alternatives
+
+- **Roll back the three lessons.** Wrong semantics (they are live rules, not
+  reverted) and breaks dedup — duplicates would regenerate.
+- **Raise `audit.drift_alarm_threshold`.** Masks the signal and would hide a
+  genuine future drift regression. Threshold tuning to silence an alarm is the
+  same anti-pattern ADR 0010 rejected for replay drift.
+- **Document as an accepted false-positive (ADR only, no code).** The alert would
+  keep firing every run; it does not address the operator-noise problem.
+
+## References
+
+- ADR [0005 — P5 router and auditor](0005-p5-router-and-auditor.md) — drift alarm origin.
+- ADR [0010 — replay drift informational](0010-replay-drift-informational.md) — prior "don't tune thresholds to silence alarms" precedent.
+- `agents-md` PR #31 — the externalization of the three lessons.
+- `config/thresholds.toml` — `audit.drift_alarm_threshold` (unchanged).

--- a/mcp/src/server-tools.ts
+++ b/mcp/src/server-tools.ts
@@ -39,7 +39,7 @@ export const statusInputSchema = {} as const;
 
 export const lessonsInputSchema = {
   status: z
-    .enum(["pending", "proposed", "rejected", "approved", "applied", "rolled_back"])
+    .enum(["pending", "proposed", "rejected", "approved", "applied", "rolled_back", "externalized"])
     .optional(),
   limit: z.number().int().positive().max(200).optional(),
 } as const;
@@ -189,7 +189,7 @@ export const toolDefinitions = {
   bsela_lessons: {
     title: "BSELA lessons",
     description:
-      "Return stored BSELA lessons as a JSON array plus structuredContent.lessons. Optionally filter by status (pending|proposed|rejected|approved|applied|rolled_back) and cap results with limit. Each item includes id, status, scope, confidence, rule, why, how_to_apply, hit_count, and created_at.",
+      "Return stored BSELA lessons as a JSON array plus structuredContent.lessons. Optionally filter by status (pending|proposed|rejected|approved|applied|rolled_back|externalized) and cap results with limit. Each item includes id, status, scope, confidence, rule, why, how_to_apply, hit_count, and created_at.",
     inputSchema: lessonsInputSchema,
   },
   bsela_sessions: {

--- a/src/bsela/cli.py
+++ b/src/bsela/cli.py
@@ -553,6 +553,46 @@ def rollback(
 
 
 @app.command()
+def externalize(
+    lesson_id: Annotated[str, typer.Argument(help="Lesson identifier to externalize.")],
+    note: Annotated[
+        str | None, typer.Option("--note", "-n", help="Where it was externalized (e.g. PR link).")
+    ] = None,
+) -> None:
+    """Mark a lesson as externalized — graduated into agents-md as a durable rule.
+
+    Sets the status to ``externalized`` (ADR 0011). Such a lesson lives in your
+    AGENTS.md and is surfaced by the editor directly, so it can never accrue a
+    local ``hit_count``; it therefore LEAVES the drift gate (no longer counted as
+    a stale applied lesson) but is KEPT in the distiller dedup corpus so the same
+    rule is never regenerated as a duplicate candidate. This command only updates
+    the local BSELA store; it does not write to agents-md.
+
+    Exit code 0: externalized successfully or already externalized.
+    Exit code 1: lesson not found.
+    """
+    try:
+        lesson = resolve_lesson(lesson_id)
+    except LookupError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+    if lesson is None:
+        typer.secho(f"externalize: lesson not found: {lesson_id}", fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+    if lesson.status == "externalized":
+        typer.echo(f"externalize: {lesson.id} is already externalized — nothing to do.")
+        raise typer.Exit(code=0)
+
+    prev_status = lesson.status
+    update_lesson_status(lesson.id, status="externalized", note=note)
+    typer.secho(
+        f"externalized: [{prev_status}] {lesson.rule}",
+        fg=typer.colors.GREEN,
+    )
+
+
+@app.command()
 def replay(
     session_id: Annotated[str, typer.Argument(help="Session ID to replay.")],
     no_save: Annotated[
@@ -1053,6 +1093,7 @@ def _audit_json_payload(report_data: object) -> dict[str, object]:
         "drift": {
             "lessons_total": report_data.drift.lessons_total,
             "lessons_stale": report_data.drift.lessons_stale,
+            "lessons_externalized": report_data.drift.lessons_externalized,
             "threshold": report_data.drift.threshold,
             "drift_fraction": report_data.drift.drift_fraction,
             "over_threshold": report_data.drift.over_threshold,

--- a/src/bsela/core/auditor.py
+++ b/src/bsela/core/auditor.py
@@ -69,6 +69,9 @@ class DriftSnapshot:
     lessons_total: int
     lessons_stale: int
     threshold: float
+    # Lessons graduated into agents-md (status ``externalized``, ADR 0011). They
+    # are excluded from ``lessons_total`` by design — reported for transparency.
+    lessons_externalized: int = 0
 
     @property
     def drift_fraction(self) -> float:
@@ -218,6 +221,9 @@ def build_audit(
                 ).all()
             )
         )
+        externalized_count = len(
+            list(s.exec(select(Lesson).where(Lesson.status == "externalized")).all())
+        )
         metrics = list(
             s.exec(
                 select(Metric).where(Metric.created_at >= start).where(Metric.created_at <= end)
@@ -252,6 +258,7 @@ def build_audit(
         lessons_total=lessons_tracked_count,
         lessons_stale=stale_count,
         threshold=cfg.audit.drift_alarm_threshold,
+        lessons_externalized=externalized_count,
     )
 
     replay_drift_snapshot = ReplayDriftSnapshot(
@@ -376,6 +383,7 @@ def render_markdown(report: AuditReport) -> str:
         f"({report.drift.drift_fraction:.1%}, "
         f"threshold {report.drift.threshold:.1%})"
     )
+    lines.append(f"- Externalized (durable in agents-md): {report.drift.lessons_externalized}")
     lines.append("")
 
     lines.append("## Replay Drift")

--- a/src/bsela/llm/distiller.py
+++ b/src/bsela/llm/distiller.py
@@ -253,10 +253,15 @@ def distill_session(
         # lessons regardless of recency — otherwise a candidate that duplicates
         # an older approved rule slips through once newer pending rows push it
         # past ``recent_lessons_limit`` (root cause of the 2026-05-09 17/17 dup
-        # batch). Fetched lazily inside this branch to avoid two unbounded DB
-        # reads on healthy sessions and ``persist=False`` calls.
-        approved_corpus = list_lessons(status="approved", limit=None) + list_lessons(
-            status="applied", limit=None
+        # batch). ``externalized`` rules (graduated into agents-md, ADR 0011) are
+        # included too: they have left the drift gate but must still suppress
+        # regeneration of a rule that already lives as a durable AGENTS.md entry.
+        # Fetched lazily inside this branch to avoid two unbounded DB reads on
+        # healthy sessions and ``persist=False`` calls.
+        approved_corpus = (
+            list_lessons(status="approved", limit=None)
+            + list_lessons(status="applied", limit=None)
+            + list_lessons(status="externalized", limit=None)
         )
         saved_this_batch: list[Lesson] = list(recent) + list(approved_corpus)
         for candidate in response.lessons:

--- a/src/bsela/memory/models.py
+++ b/src/bsela/memory/models.py
@@ -66,6 +66,11 @@ class Lesson(SQLModel, table=True):
     why: str
     how_to_apply: str
     confidence: float = Field(default=0.0)
+    # Lifecycle: pending → proposed → approved → applied. Terminal states:
+    # ``rolled_back`` (reverted — leaves routing, dedup, and audit counts) and
+    # ``externalized`` (graduated into agents-md as a durable rule — leaves the
+    # drift gate but is KEPT in the distiller dedup corpus so it is never
+    # regenerated as a duplicate candidate). See ADR 0011.
     status: str = Field(default="pending", index=True)
     hit_count: int = Field(default=0)
     created_at: datetime = Field(default_factory=_utcnow, index=True)

--- a/tests/test_auditor.py
+++ b/tests/test_auditor.py
@@ -171,6 +171,27 @@ def test_hit_lesson_does_not_count_as_stale(tmp_bsela_home: Path) -> None:
     assert report.drift.lessons_stale == 0
 
 
+def test_externalized_lesson_excluded_from_drift(tmp_bsela_home: Path) -> None:
+    """Externalized lessons (ADR 0011) leave the drift gate, even when old + unused.
+
+    They live as durable rules in agents-md and can never accrue a local
+    hit_count, so counting them as stale is a structural false-positive. They are
+    excluded from ``lessons_total`` and surfaced via ``lessons_externalized``.
+    """
+    old = NOW - timedelta(days=STALE_LESSON_AGE_DAYS + 5)
+    _lesson(status="externalized", hit_count=0, created_at=old)
+    _lesson(status="externalized", hit_count=0, created_at=old)
+    _lesson(status="externalized", hit_count=0, created_at=old)
+
+    report = build_audit(window_days=30, now=NOW)
+    assert report.drift.lessons_total == 0
+    assert report.drift.lessons_stale == 0
+    assert report.drift.lessons_externalized == 3
+    assert report.drift.drift_fraction == pytest.approx(0.0)
+    assert not report.drift.over_threshold
+    assert not any("DRIFT" in alert for alert in report.alerts)
+
+
 def test_adr_scan_via_env_override(
     tmp_bsela_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -19,7 +19,13 @@ from bsela.core.process import ProcessResult
 from bsela.llm.distiller import DistillationResult
 from bsela.llm.types import DistillResponse, JudgeVerdict
 from bsela.memory.models import ErrorRecord, Lesson, SessionRecord
-from bsela.memory.store import list_sessions, save_error, save_lesson, update_lesson_status
+from bsela.memory.store import (
+    get_lesson,
+    list_sessions,
+    save_error,
+    save_lesson,
+    update_lesson_status,
+)
 
 
 def test_version_flag() -> None:
@@ -31,7 +37,7 @@ def test_version_flag() -> None:
 def test_help_lists_commands() -> None:
     result = CliRunner().invoke(app, ["--help"])
     assert result.exit_code == 0
-    for cmd in ("status", "ingest", "review", "lessons", "rollback"):
+    for cmd in ("status", "ingest", "review", "lessons", "rollback", "externalize"):
         assert cmd in result.stdout
 
 
@@ -211,6 +217,70 @@ def test_rollback_already_rolled_back_exits_0(
     result = CliRunner().invoke(app, ["rollback", lesson.id])
     assert result.exit_code == 0
     assert "already rolled back" in result.stdout
+
+
+def test_externalize_ambiguous_prefix_exits_1(tmp_bsela_home: Path) -> None:
+    with patch("bsela.cli.resolve_lesson", side_effect=LookupError("ambiguous")):
+        result = CliRunner().invoke(app, ["externalize", "abc"])
+    assert result.exit_code == 1
+    assert "ambiguous" in result.stdout
+
+
+def test_externalize_not_found_exits_1(tmp_bsela_home: Path) -> None:
+    result = CliRunner().invoke(app, ["externalize", "no-such-id"])
+    assert result.exit_code == 1
+    assert "not found" in result.stdout
+
+
+def test_externalize_applied_lesson_succeeds(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions()[0].id
+    err = save_error(
+        ErrorRecord(session_id=session_id, category="loop", severity="medium", snippet="test")
+    )
+    lesson = save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule="Never do Z",
+            why="reason",
+            how_to_apply="action",
+            confidence=0.9,
+            status="applied",
+        )
+    )
+    result = CliRunner().invoke(app, ["externalize", lesson.id, "--note", "PR #31"])
+    assert result.exit_code == 0
+    assert "externalized" in result.stdout
+    refreshed = get_lesson(lesson.id)
+    assert refreshed is not None
+    assert refreshed.status == "externalized"
+
+
+def test_externalize_already_externalized_exits_0(
+    tmp_bsela_home: Path, sample_clean_session: Path
+) -> None:
+    ingest_file(sample_clean_session)
+    session_id = list_sessions()[0].id
+    err = save_error(
+        ErrorRecord(session_id=session_id, category="loop", severity="medium", snippet="test")
+    )
+    lesson = save_lesson(
+        Lesson(
+            source_error_id=err.id,
+            scope="project",
+            rule="Never do W",
+            why="reason",
+            how_to_apply="action",
+            confidence=0.9,
+            status="externalized",
+        )
+    )
+    result = CliRunner().invoke(app, ["externalize", lesson.id])
+    assert result.exit_code == 0
+    assert "already externalized" in result.stdout
 
 
 def test_doctor_exits_without_crash(tmp_bsela_home: Path) -> None:

--- a/tests/test_distiller.py
+++ b/tests/test_distiller.py
@@ -291,6 +291,31 @@ def test_distill_dedup_blocks_approved_outside_recent_window(tmp_bsela_home: Pat
     assert count_lessons() == 6
 
 
+def test_distill_dedup_blocks_externalized_lesson(tmp_bsela_home: Path) -> None:
+    """An ``externalized`` lesson (ADR 0011) must still suppress duplicates.
+
+    Externalized rules leave the drift gate but remain live in agents-md, so the
+    distiller must keep them in the dedup corpus — otherwise a rule that was
+    graduated into AGENTS.md gets regenerated as a fresh candidate.
+    """
+    sid = ingest_file(FIXTURES / "looped-read.jsonl").session_id
+    detect_errors(sid)
+
+    rule = "Stop retrying Read on a missing path after the first ENOENT"
+    externalized = _make_lesson(rule)
+    externalized.status = "externalized"
+    save_lesson(externalized)
+
+    client = FakeLLMClient(
+        judge_response=_unhealthy_verdict(),
+        distill_response=_sample_distill(),  # returns the same rule
+    )
+    result = distill_session(sid, client=client, recent_lessons_limit=10)
+    assert result.distilled is True
+    assert result.persisted == (), "candidate duplicating an externalized rule must be deduped"
+    assert count_lessons(status="pending") == 0  # nothing new persisted
+
+
 def test_distill_dedup_within_batch(tmp_bsela_home: Path) -> None:
     """Two identical candidates in the same response — only one should persist."""
     sid = ingest_file(FIXTURES / "looped-read.jsonl").session_id


### PR DESCRIPTION
## Problem
`bsela audit` raised a **blocking** DRIFT alert on every run:
`DRIFT: 3/3 applied lessons unused for 14+ days (100.0% > 50.0% threshold)`.

Root cause: the three `applied` lessons (`55adbcb3`, `809875ce`, `6a6601cb`) were promoted into `agents-md` `AGENTS.md` via PR #31. `hit_count` only increments through `bsela lessons --bump`; an externalized rule is read from `AGENTS.md` by the editor directly, so it can **never** accrue a local hit and is permanently counted as stale. The alarm was structural noise that fires at 100% forever — training the operator to ignore the auditor.

## Fix — `externalized` terminal status (ADR 0011)
- **auditor.py**: `tracked_statuses` stays `("applied","approved")`, so `externalized` lessons leave the drift gate automatically. New `DriftSnapshot.lessons_externalized` count rendered in the report and `--json`.
- **distiller.py**: externalized lessons stay in the dedup corpus — the one behavioural difference from `rolled_back` — so a graduated rule is never regenerated as a duplicate candidate. Regression-tested.
- **cli.py**: new `bsela externalize <id>` command, mirroring `rollback`.
- **mcp/server-tools.ts**: `externalized` added to the `bsela_lessons` status enum + description (`trackHits` deliberately excludes it — these can't be hit).
- **models.py**: terminal status documented.
- The 3 lessons migrated `applied → externalized` in the store.

## Result
`bsela audit --json` → `alerts: []`, `drift_fraction: 0.0`. **No threshold changed; `AGENTS.md` untouched.**

## Why not the alternatives (see ADR 0011)
- Roll back the 3 — wrong semantics + breaks dedup (duplicates regenerate).
- Raise `drift_alarm_threshold` — masks genuine future drift (same anti-pattern ADR 0010 rejected).
- Document-only — alert keeps firing.

## Tests
- `test_auditor.py`: externalized lessons excluded from drift; no DRIFT alert.
- `test_distiller.py`: candidate duplicating an externalized rule is deduped.
- `test_cli_smoke.py`: `externalize` transitions status, idempotent, not-found / ambiguous → exit 1.
- `make check`: **448 passed, 99.80%** coverage. `make mcp-check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)