### PR TITLE
fix(ci): add author-association guard to auto-merge + fill CHANGELOG

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,13 +13,24 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
-    # Only same-repo branches (owner/collaborator PRs + Dependabot); external forks are skipped.
+    # Gate on same-repo branch AND a trusted author: either an
+    # owner/member/collaborator (author-association allowlist) or Dependabot,
+    # whose same-repo dependency PRs are allowed to auto-merge.
+    # External forks and other bot/contributor PRs are skipped.
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        github.event.pull_request.user.login == 'dependabot[bot]'
+      )
     steps:
       - name: Enable auto-merge
         run: gh pr merge --auto --squash "$PR_URL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ called out under a `Breaking` heading.
 
 ## [Unreleased]
 
+### Added
+
+- Externalized lesson status (`externalized`): lessons promoted to production rules in `~/AGENTS.md` are now classified as `externalized` rather than cycling back through `pending` — prevents false-positive DRIFT alerts after a rules update.
+
+### Fixed
+
+- Self-referential guard now covers all BSELA MCP envelope keys, not only `BSELA_HOME` — prevents the session capture from re-ingesting its own running environment.
+- Stack-trace detector no longer fires on BSELA's own serialized error output in `stack_trace` fields — reduces false-positive error classification on recursive BSELA runs.
+
 ## [0.2.0] - 2026-06-15
 
 Public-readiness hardening release. The default config now ships inside the


### PR DESCRIPTION
## Summary

- **Security fix**: `auto-merge.yml` was missing the `author_association` guard that `agents-md` has. Without it, any same-repo PR (including unknown bots or external contributors who manage to push a same-repo branch) would auto-merge without any review gate. Added the `OWNER/MEMBER/COLLABORATOR || dependabot[bot]` allowlist — identical to the pattern used in `agents-md`.

- **CHANGELOG hygiene**: `[Unreleased]` section was empty despite three meaningful commits since v0.2.0. Filled in:
  - **Added**: `externalized` lesson status (feat in #104)
  - **Fixed**: self-referential guard covering all MCP envelope keys (#105)
  - **Fixed**: stack-trace detector false-positives on BSELA's own serialized output (#103)

## Test plan

- [ ] CI passes (auto-merge, lint-and-test)
- [ ] Verify no external-contributor PR can auto-merge after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)