### PR TITLE
docs(codex): add repo-local Codex guidance

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,5 @@
+# Repo-local Codex defaults for this workspace.
+
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+allow_login_shell = true

--- a/.gitignore
+++ b/.gitignore
@@ -93,5 +93,10 @@ site/
 # Claude Code (commit shared settings; ignore machine-local perms + transcripts)
 .claude/*
 !.claude/settings.json
+
+# Codex CLI
+!.codex/
+.codex/*
+!.codex/config.toml
 !.claude/agents/
 !.claude/agents/**

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ under [`docs/orchestrator/`](docs/orchestrator/README.md). Run
 `ANTHROPIC_API_KEY` (or OAuth token) to Actions secrets, then use `@claude` on
 PRs/issues. See [adapters/claude/README.md §7](adapters/claude/README.md).
 
+**Codex:** use the repo root `AGENTS.md` plus the tracked `.codex/config.toml`
+for Codex CLI workspace defaults. The companion `CODEX.md` has the direct
+handoff for this repo.
+
 **Cursor:** to avoid spurious workflow diagnostics, open [`bsela.code-workspace`](bsela.code-workspace) (see [adapters/cursor/README.md](adapters/cursor/README.md)).
 
 **Git:** if `~/.gitignore_global` ignores `.vscode/`, Git will refuse a plain `git add` on [`.vscode/settings.json`](.vscode/settings.json). Use `git add -f .vscode/settings.json` for that path, or drop `.vscode/` from your global ignore.


### PR DESCRIPTION
## Summary\n- add repo-local .codex/config.toml defaults for Codex CLI\n- unignore only .codex/config.toml so the config is versioned\n- document Codex usage in README.md\n\n## Verification\n- git diff --check\n- python3 tomllib parse of .codex/config.toml\n